### PR TITLE
Make unit tests able to send backtrace on fatal errors

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -50,6 +50,9 @@ if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
 }
 define('GLPI_LOG_DIR', __DIR__ . '/logs');
 @mkdir(GLPI_LOG_DIR);
+if (!defined('STDERR')) {
+   define('STDERR', fopen(GLPI_LOG_DIR . 'stderr.log', 'w'));
+}
 
 // Giving --debug argument to atoum will be detected by GLPI too
 // the error handler in Toolbox may output to stdout a message and break process communication

--- a/tests/suite-integration/PluginFlyvemdmAgent.php
+++ b/tests/suite-integration/PluginFlyvemdmAgent.php
@@ -36,7 +36,6 @@ use Glpi\Test\CommonTestCase;
 
 /**
  * TODO: testDeviceCountLimit should go to Entity unit test, remove inline engine when change that.
- * @engine inline
  */
 class PluginFlyvemdmAgent extends CommonTestCase {
 


### PR DESCRIPTION
Fix #314

