### PR TITLE
Qr code in email was missing

### DIFF
--- a/inc/invitation.class.php
+++ b/inc/invitation.class.php
@@ -297,8 +297,8 @@ class PluginFlyvemdmInvitation extends CommonDBTM {
       $user = new User();
       $user->getFromDB($this->fields['users_id']);
       $invitationToken = $this->fields['invitation_token'];
-      $entities_id = $this->fields['entities_id'];
-      $encodedRequest = $this->getEnrollmentUrl($user, $invitationToken, $entities_id);
+      $entityId = $this->fields['entities_id'];
+      $encodedRequest = $this->getEnrollmentUrl($user, $invitationToken, $entityId);
 
       // Generate a QRCode
       $barcodeobj = new TCPDF2DBarcode($encodedRequest, 'QRCODE,L');
@@ -328,7 +328,7 @@ class PluginFlyvemdmInvitation extends CommonDBTM {
       // Generate a document with the QR code
       $input = [];
       $document = new Document();
-      $input['entities_id'] = $entities_id;
+      $input['entities_id'] = $entityId;
       $input['is_recursive'] = '0';
       $input['name'] = addslashes(__('Enrollment QR code', 'flyvemdm'));
       $input['_filename'] = [$tmpFile];

--- a/inc/notificationtargetinvitation.class.php
+++ b/inc/notificationtargetinvitation.class.php
@@ -97,8 +97,13 @@ class PluginFlyvemdmNotificationTargetInvitation extends NotificationTarget {
                $invitation = $event->obj;
 
                // Get the document containing the QR code
+               $documentItem = new Document_Item();
+               $documentItem->getFromDBByCrit([
+                  'itemtype' => PluginFlyvemdmInvitation::class,
+                  'items_id' => $invitation->getID()
+               ]);
                $document = new Document();
-               $document->getFromDB($invitation->getField('documents_id'));
+               $document->getFromDB($documentItem->getField('documents_id'));
 
                // Get the general config of Flyve MDM
                $config = Config::getConfigurationValues('flyvemdm', ['invitation_deeplink']);
@@ -107,9 +112,7 @@ class PluginFlyvemdmNotificationTargetInvitation extends NotificationTarget {
                $entityConfig = new PluginFlyvemdmEntityConfig();
                $entityConfig->getFromDBByCrit(['entities_id' => $invitation->getField('entities_id')]);
 
-               $user = new User();
-               $user->getFromDB($invitation->getField('users_id'));
-               $encodedRequest = $invitation->getEnrollmentUrl($user, $invitation->getField('invitation_token'), $invitation->getField('entities_id'));
+               $encodedRequest = $invitation->getEnrollmentUrl();
 
                // Fill the template
                $event->data['##flyvemdm.qrcode##'] = Document::getImageTag($document->getField('tag'));

--- a/tests/suite-integration/PluginFlyvemdmInvitation.php
+++ b/tests/suite-integration/PluginFlyvemdmInvitation.php
@@ -78,9 +78,15 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
       $this->boolean($queuedNotification->isNewItem())->isFalse();
 
       // Check a QR code is created
+      $documentItem = new \Document_Item();
+      $documentItem->getFromDBByCrit([
+         'itemtype' => \PluginFlyvemdmInvitation::class,
+         'items_id' => $invitation->getID(),
+      ]);
+      $this->boolean($documentItem->isNewItem())->isFalse();
       $document = new \Document();
       $documentFk = \Document::getForeignKeyField();
-      $document->getFromDB($invitation->getField($documentFk));
+      $document->getFromDB($documentItem->getField($documentFk));
       $this->boolean($document->isNewItem())->isFalse();
 
       // Check the pending email has the QR code as attachment

--- a/tests/suite-unit/PluginFlyvemdmInvitation.php
+++ b/tests/suite-unit/PluginFlyvemdmInvitation.php
@@ -63,14 +63,6 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
    }
 
    /**
-    * @return object
-    */
-   public function createNewInstance() {
-      $instance = $this->newTestedInstance();
-      return $instance;
-   }
-
-   /**
     * @tags testClass
     */
    public function testClass() {
@@ -83,7 +75,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
     * @tags testGetEnumInvitationStatus
     */
    public function testGetEnumInvitationStatus() {
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
       $this->array($result = $instance->getEnumInvitationStatus())
          ->hasKeys(['pending', 'done'])
          ->string($result['pending'])->isEqualTo('Pending')
@@ -112,7 +104,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
     * @tags testGetRights
     */
    public function testGetRights() {
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
       $this->array($result = $instance->getRights())->containsValues([
          'Create',
          'Read',
@@ -132,7 +124,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
          'Document move succeeded.',
          'The user already exists and has been deleted. You must restore or purge him first.',
       ];
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
 
       // empty array
       $this->boolean($instance->prepareInputForAdd([]))->isFalse();
@@ -190,7 +182,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
     * @tags testPrepareInputForUpdate
     */
    public function testPrepareInputForUpdate() {
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
       $this->array($instance->prepareInputForUpdate([]));
    }
 
@@ -198,7 +190,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
     * @tags testGetFromDBByToken
     */
    public function testGetFromDBByToken() {
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
       $this->boolean($instance->getFromDBByToken('invalidToken'))->isFalse();
    }
 
@@ -206,7 +198,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
     * @tags testShowForm
     */
    public function testShowForm() {
-      $instance = $this->createNewInstance();
+      $instance = $this->newTestedInstance();
       ob_start();
       $instance->showForm(0);
       $result = ob_get_contents();

--- a/tests/suite-unit/PluginFlyvemdmInvitation.php
+++ b/tests/suite-unit/PluginFlyvemdmInvitation.php
@@ -115,6 +115,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
 
    /**
     * @tags testPrepareInputForAdd
+    * @engine inline
     */
    public function testPrepareInputForAdd() {
       $uniqueEmail = $this->getUniqueEmail();
@@ -152,18 +153,16 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
          \PluginFlyvemdmCommon::recursiveRmdir($destination);
       }
       $result = $instance->prepareInputForAdd($input);
-      $this->boolean($instance->isNewItem())->isTrue()->array($result)->hasKeys([
-         '_useremails',
-         'entities_id',
-         'users_id',
-         'invitation_token',
-         'expiration_date',
-         'documents_id',
-      ])->string($result['_useremails'])->isEqualTo($uniqueEmail)->integer($result['documents_id'])
-         ->string($result['invitation_token'])->string($expiration = $result['expiration_date']);
-      $this->string($_SESSION["MESSAGE_AFTER_REDIRECT"][0][1])
-         ->isEqualTo($sessionMessages[2], json_encode($_SESSION['MESSAGE_AFTER_REDIRECT'], 128));
-      unset($_SESSION["MESSAGE_AFTER_REDIRECT"][0]);
+      $this->boolean($instance->isNewItem())->isTrue()
+         ->array($result)->hasKeys([
+            '_useremails',
+            'entities_id',
+            'users_id',
+            'invitation_token',
+            'expiration_date',])
+         ->string($result['_useremails'])->isEqualTo($uniqueEmail)
+         ->string($result['invitation_token'])
+         ->string($expiration = $result['expiration_date']);
 
       // check if expiration date is valid
       $this->if($expiration = new \DateTime($expiration))

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
@@ -219,7 +219,6 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
 
    /**
     * @tags testShowValueInput
-    * @engine inline
     */
    public function testShowValueInput() {
       list($policy) = $this->createNewPolicyInstance();


### PR DESCRIPTION
It seems the QR code must be linked to the invitation with the relation table glpi_documents_items.

The PR needs cleanup : the column documents_id in the invitation is now obsolete. Needs to migrate the existing rows to the new way and probably update the hooks.
