### PR TITLE
Fix wrong user profile in enrollment

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1053,7 +1053,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
     * @return array|bool
     */
    protected function enrollByInvitationToken($input) {
-      global $LOADED_PLUGINS;
+      global $LOADED_PLUGINS, $DB;
 
       $invitationToken  = isset($input['_invitation_token']) ? $input['_invitation_token'] : null;
       $email            = isset($input['_email']) ? $input['_email'] : null;
@@ -1305,6 +1305,14 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          $this->logInvitationEvent($invitation, $event);
          return false;
       }
+
+      // Awful hack because the current user profile does not
+      // have more rights than the profile of the agent.
+      // @see User::post_addItem
+      $profileId = $config['agent_profiles_id'];
+      $agentUserId = $agentAccount->getID();
+      $DB->query("UPDATE `glpi_profiles_users` SET `profiles_id` = '$profileId'
+                  WHERE `users_id` = '$agentUserId'");
 
       $agentToken = User::getToken($agentAccount->getID(), 'api_token');
       if ($agentToken === false) {

--- a/tests/suite-install/Config.php
+++ b/tests/suite-install/Config.php
@@ -92,6 +92,16 @@ class Config extends CommonTestCase {
          'mqtt_broker_internal_address' => '127.0.0.1',
       ]);
 
+      $config = \Config::getConfigurationValues('flyvemdm');
+
+      // Test an agent's user profile exists
+      $this->integer((int) $config['agent_profiles_id'])->isGreaterThan(0);
+      $agentProfileId = $config['agent_profiles_id'];
+      $profile = new \Profile();
+      $profile->getFromDB($agentProfileId);
+      $this->boolean($profile->isNewItem())->isFalse();
+      $this->string($profile->getField('name'))->isEqualTo('Flyve MDM device agent users');
+
       // Force the MQTT backend's credentials
       // Useful to force the credientials to be the same as a development database
       // and not force broker's reconfiguration when launching tests on the test-dedicates DB
@@ -117,7 +127,7 @@ class Config extends CommonTestCase {
    }
 
    /**
-    * Configure GLPI to isntall the plugin
+    * Configure GLPI to install the plugin
     */
    private function configureGLPI() {
       global $CFG_GLPI;


### PR DESCRIPTION
### Changes description

When a device enrolls an agent is created in the DB with an associated user.

This user does not has the expected profile :-1: 

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

