### PR TITLE
Code cleanup

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -36,7 +36,7 @@ if (!defined('GLPI_ROOT')) {
 /**
  * @since 0.1.0
  */
-class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable {
+class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiableInterface {
 
    const ENROLL_DENY             = 0;
    const ENROLL_INVITATION_TOKEN = 1;
@@ -1645,14 +1645,14 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getAgents()
+    * @see PluginFlyvemdmNotifiableInterface::getAgents()
     */
    public function getAgents() {
       return [$this];
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getPackages()
+    * @see PluginFlyvemdmNotifiableInterface::getPackages()
     */
    public function getPackages() {
       if ($this->getID() > 0) {
@@ -1667,7 +1667,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getFiles()
+    * @see PluginFlyvemdmNotifiableInterface::getFiles()
     */
    public function getFiles() {
       if ($this->getID() > 0) {
@@ -1681,7 +1681,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getFleet()
+    * @see PluginFlyvemdmNotifiableInterface::getFleet()
     */
    public function getFleet() {
       $fleet = null;
@@ -1963,4 +1963,6 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          $this->sendUnenrollQuery();
       }
    }
+
+
 }

--- a/inc/fleet.class.php
+++ b/inc/fleet.class.php
@@ -36,7 +36,7 @@ if (!defined('GLPI_ROOT')) {
 /**
  * @since 0.1.0
  */
-class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable {
+class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiableInterface {
 
    /**
     * @var string $rightname name of the right in DB
@@ -287,7 +287,7 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
 
    /**
     *
-    * @see PluginFlyvemdmNotifiable::getTopic()
+    * @see PluginFlyvemdmNotifiableInterface::getTopic()
     */
    public function getTopic() {
       if (!isset($this->fields['id'])) {
@@ -392,7 +392,7 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getFleet()
+    * @see PluginFlyvemdmNotifiableInterface::getFleet()
     */
    public function getFleet() {
       if ($this->isNewItem()) {
@@ -423,7 +423,7 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
    }
 
    /**
-    * @see PluginFlyvemdmNotifiable::getFiles()
+    * @see PluginFlyvemdmNotifiableInterface::getFiles()
     */
    public function getFiles() {
       $files = [];
@@ -489,7 +489,7 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
 
    /**
     *
-    * @see PluginFlyvemdmNotifiable::notify()
+    * @see PluginFlyvemdmNotifiableInterface::notify()
     * @param string $topic
     * @param string $mqttMessage
     * @param integer $qos

--- a/inc/notifiableinterface.class.php
+++ b/inc/notifiableinterface.class.php
@@ -36,7 +36,7 @@ if (! defined('GLPI_ROOT')) {
 /**
  * @since 0.1.31
  */
-interface PluginFlyvemdmNotifiable {
+interface PluginFlyvemdmNotifiableInterface {
 
    /**
     * Gets the topic related to the notifiable

--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -126,7 +126,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param integer $itemId
     * @return bool
     */
-   public function canApply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function canApply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       return $this->canApply;
    }
 

--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -193,7 +193,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param integer $itemId
     * @return bool
     */
-   public function apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
       return true;
    }
 
@@ -204,7 +204,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param integer $itemId
     * @return bool
     */
-   public function unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
       // Do nothing by default
       // May be overriden by inhrited classes
       return true;

--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -135,20 +135,18 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmFleet $fleet
-    * @return bool
+    * @return boolean
     */
    public function unicityCheck($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
-      if ($this->unicityRequired) {
-         $policyId            = $this->policyData->getID();
-         $fleetId             = $fleet->getID();
-         $task = new PluginFlyvemdmTask();
-         $relationCollection  = $task->find("`plugin_flyvemdm_fleets_id`='$fleetId' AND `plugin_flyvemdm_policies_id`='$policyId'", '', '1');
-         if (count($relationCollection) > 0) {
-            // A relation already exists for this policy and this fleet
-            return false;
-         }
+      if (!$this->unicityRequired) {
+         return true;
       }
-      return true;
+
+      $policyId            = $this->policyData->getID();
+      $fleetId             = $fleet->getID();
+      $task                = new PluginFlyvemdmTask();
+      $relationCollection  = $task->find("`plugin_flyvemdm_fleets_id`='$fleetId' AND `plugin_flyvemdm_policies_id`='$policyId'", '', '1');
+      return (count($relationCollection) === 0);
    }
 
    /**
@@ -156,7 +154,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmFleet $fleet
-    * @return bool
+    * @return boolean
     */
    public function conflictCheck($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       return true;

--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -120,10 +120,10 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
    }
 
    /**
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     * @return bool
     */
    public function canApply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
@@ -187,24 +187,24 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
    }
 
    /**
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
     * @return bool
+    * @param PluginFlyvemdmFleet $fleet
     */
-   public function pre_apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_apply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       return true;
    }
 
    /**
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     * @return bool
     */
-   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       // Do nothing by default
       // May be overriden by inhrited classes
       return true;

--- a/inc/policydeployapplication.class.php
+++ b/inc/policydeployapplication.class.php
@@ -134,7 +134,7 @@ class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase imp
     * @return bool
     */
    public function conflictCheck($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
-      // Check there is not already a removal policy (to avoind opposite policy)
+      // Check there is not already a removal policy (to avoid opposite policy)
       $package = new PluginFlyvemdmPackage();
       if (!$package->getFromDB($itemId)) {
          // Cannot apply a non existing applciation
@@ -162,13 +162,13 @@ class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase imp
    }
 
    /**
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     * @return bool
     */
-   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       $decodedValue = json_decode($value, JSON_OBJECT_AS_ARRAY);
       if ($this->integrityCheck($decodedValue, $itemtype, $itemId) === false) {
          return false;

--- a/inc/policydeployapplication.class.php
+++ b/inc/policydeployapplication.class.php
@@ -168,7 +168,7 @@ class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase imp
     * @param integer $itemId
     * @return bool
     */
-   public function unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
       $decodedValue = json_decode($value, JSON_OBJECT_AS_ARRAY);
       if ($this->integrityCheck($decodedValue, $itemtype, $itemId) === false) {
          return false;

--- a/inc/policydeployfile.class.php
+++ b/inc/policydeployfile.class.php
@@ -207,7 +207,7 @@ class PluginFlyvemdmPolicyDeployfile extends PluginFlyvemdmPolicyBase implements
     * @param integer $itemId
     * @return bool
     */
-   public function unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
       $value = json_decode($value, JSON_OBJECT_AS_ARRAY);
       if ($this->integrityCheck($value, $itemtype, $itemId) === false) {
          return false;

--- a/inc/policydeployfile.class.php
+++ b/inc/policydeployfile.class.php
@@ -201,13 +201,13 @@ class PluginFlyvemdmPolicyDeployfile extends PluginFlyvemdmPolicyBase implements
    }
 
    /**
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     * @return bool
     */
-   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
+   public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet) {
       $value = json_decode($value, JSON_OBJECT_AS_ARRAY);
       if ($this->integrityCheck($value, $itemtype, $itemId) === false) {
          return false;

--- a/inc/policyinterface.class.php
+++ b/inc/policyinterface.class.php
@@ -51,7 +51,7 @@ interface PluginFlyvemdmPolicyInterface {
     * @param mixed $itemtype the itemtype of an item
     * @param integer $itemId the id of an item
     */
-   public function canApply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
+   public function canApply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet);
 
    /**
     * Check the unicity of the policy

--- a/inc/policyinterface.class.php
+++ b/inc/policyinterface.class.php
@@ -106,7 +106,7 @@ interface PluginFlyvemdmPolicyInterface {
     * @param mixed $itemtype
     * @param integer $itemId
     */
-   public function apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
+   public function pre_apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
 
    /**
     * Actions done after a policy is unapplied to a fleet
@@ -115,7 +115,7 @@ interface PluginFlyvemdmPolicyInterface {
     * @param mixed $itemtype
     * @param integer $itemId
     */
-   public function unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
+   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
 
    /**
     * return HTML input to set policy value

--- a/inc/policyinterface.class.php
+++ b/inc/policyinterface.class.php
@@ -46,10 +46,10 @@ interface PluginFlyvemdmPolicyInterface {
 
    /**
     * Check the policy may apply with respect of unicity constraint
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype the itemtype of an item
     * @param integer $itemId the id of an item
+    * @param PluginFlyvemdmFleet $fleet
     */
    public function canApply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet);
 
@@ -101,21 +101,21 @@ interface PluginFlyvemdmPolicyInterface {
 
    /**
     * Actions done before a policy is applied to a fleet
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     */
-   public function pre_apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
+   public function pre_apply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet);
 
    /**
     * Actions done after a policy is unapplied to a fleet
-    * @param PluginFlyvemdmFleet $fleet
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    * @param PluginFlyvemdmFleet $fleet
     */
-   public function pre_unapply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId);
+   public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet);
 
    /**
     * return HTML input to set policy value

--- a/inc/policyinterface.class.php
+++ b/inc/policyinterface.class.php
@@ -67,6 +67,7 @@ interface PluginFlyvemdmPolicyInterface {
     * @param mixed $value
     * @param mixed $itemtype the itemtype of an item
     * @param integer $itemId the id of an item
+    * @return boolean False if integrity not satisfyed
     */
    public function integrityCheck($value, $itemtype, $itemId);
 
@@ -76,6 +77,7 @@ interface PluginFlyvemdmPolicyInterface {
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmFleet $fleet
+    * @return boolean False if there is a conflict with an already applied policy
     */
    public function conflictCheck($value, $itemtype, $itemId, PluginFlyvemdmFleet $fleet);
 

--- a/inc/policyremoveapplication.class.php
+++ b/inc/policyremoveapplication.class.php
@@ -79,7 +79,7 @@ class PluginFlyvemdmPolicyRemoveapplication extends PluginFlyvemdmPolicyBase imp
       $fleetId = $fleet->getID();
       $task = new PluginFlyvemdmTask();
       $rows = $task->find("`plugin_flyvemdm_fleets_id` = '$fleetId'
-            AND `plugin_flyvemdm_policies_id` = '" . $this->policyData->getID() . "' 
+            AND `plugin_flyvemdm_policies_id` = '" . $this->policyData->getID() . "'
             AND `value` = '$value'", "", "1");
       return (count($rows) == 0);
    }
@@ -99,29 +99,6 @@ class PluginFlyvemdmPolicyRemoveapplication extends PluginFlyvemdmPolicyBase imp
          $this->symbol  => $value,
       ];
       return $array;
-   }
-
-   /**
-    * @param PluginFlyvemdmFleet $fleet
-    * @param mixed $value
-    * @param mixed $itemtype
-    * @param int $itemId
-    * @return bool
-    */
-   public function apply(PluginFlyvemdmFleet $fleet, $value, $itemtype, $itemId) {
-      $this->canApply = false;
-
-      $task = new PluginFlyvemdmTask();
-      if (!$task->add([
-         'plugin_flyvemdm_fleets_id'   => $fleet->getID(),
-         'plugin_flyvemdm_policies_id' => $this->getPolicyData()->getID(),
-         'value'                       => $value,
-      ])) {
-         return false;
-      }
-
-      $this->canApply = true;
-      return true;
    }
 
    public static function getEnumSpecificStatus() {

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -304,7 +304,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
       }
 
       // TODO : What if the fleet changes, or the value changes ?
-      if (!$this->policy->pre_apply($this->fleet, $value, $itemtype, $itemId)) {
+      if (!$this->policy->pre_apply($value, $itemtype, $itemId, $this->fleet)) {
          Session::addMessageAfterRedirect(__('Failed to apply the policy', 'flyvemdm'), false,
             ERROR);
          return false;
@@ -335,8 +335,8 @@ class PluginFlyvemdmTask extends CommonDBRelation {
          Session::addMessageAfterRedirect(__('Fleet not found', 'flyvemdm'), false, ERROR);
          return false;
       }
-      return $this->policy->pre_unapply($this->fleet, $this->fields['value'], $this->fields['itemtype'],
-         $this->fields['items_id']);
+      return $this->policy->pre_unapply($this->fields['value'], $this->fields['itemtype'],
+         $this->fields['items_id'], $this->fleet);
    }
 
    /**

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -217,8 +217,8 @@ class PluginFlyvemdmTask extends CommonDBRelation {
       }
 
       // Check the policy may be applied to the fleet and the value matches requirements
-      if (!$this->policy->canApply($this->fleet, $input['value'], $input['itemtype'],
-         $input['items_id'])) {
+      if (!$this->policy->canApply($input['value'], $input['itemtype'],
+         $input['items_id'], $this->fleet)) {
          Session::addMessageAfterRedirect(__('The requirements for this policy are not met',
             'flyvemdm'), false, ERROR);
          return false;
@@ -297,7 +297,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
          }
       }
 
-      if (!$this->policy->canApply($this->fleet, $value, $itemtype, $itemId)) {
+      if (!$this->policy->canApply($value, $itemtype, $itemId, $this->fleet)) {
          Session::addMessageAfterRedirect(__('The requirements for this policy are not met',
             'flyvemdm'), false, ERROR);
          return false;

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -304,7 +304,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
       }
 
       // TODO : What if the fleet changes, or the value changes ?
-      if (!$this->policy->apply($this->fleet, $value, $itemtype, $itemId)) {
+      if (!$this->policy->pre_apply($this->fleet, $value, $itemtype, $itemId)) {
          Session::addMessageAfterRedirect(__('Failed to apply the policy', 'flyvemdm'), false,
             ERROR);
          return false;
@@ -335,7 +335,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
          Session::addMessageAfterRedirect(__('Fleet not found', 'flyvemdm'), false, ERROR);
          return false;
       }
-      return $this->policy->unapply($this->fleet, $this->fields['value'], $this->fields['itemtype'],
+      return $this->policy->pre_unapply($this->fleet, $this->fields['value'], $this->fields['itemtype'],
          $this->fields['items_id']);
    }
 
@@ -361,11 +361,11 @@ class PluginFlyvemdmTask extends CommonDBRelation {
    /**
     * MQTT publish a policy applying to the fleet
     *
-    * @param PluginFlyvemdmNotifiable $item
+    * @param PluginFlyvemdmNotifiableInterface $item
     * @throws TaskPublishPolicyBadFleetException
     * @throws TaskPublishPolicyPolicyNotFoundException
     */
-   public function publishPolicy(PluginFlyvemdmNotifiable $item) {
+   public function publishPolicy(PluginFlyvemdmNotifiableInterface $item) {
       if ($this->silent) {
          return;
       }
@@ -405,9 +405,9 @@ class PluginFlyvemdmTask extends CommonDBRelation {
 
    /**
     * Creates task status for all agents in the fleet linked to this task
-    * @param PluginFlyvemdmNotifiable $item
+    * @param PluginFlyvemdmNotifiableInterface $item
     */
-   public function createTaskStatuses(PluginFlyvemdmNotifiable $item) {
+   public function createTaskStatuses(PluginFlyvemdmNotifiableInterface $item) {
       $fleet = $item->getFleet();
       if ($fleet === null || $fleet->getField('is_default') != '0') {
          return;
@@ -434,9 +434,9 @@ class PluginFlyvemdmTask extends CommonDBRelation {
    /**
     * MQTT unpublish a policy from the fleet
     *
-    * @param PluginFlyvemdmNotifiable $item
+    * @param PluginFlyvemdmNotifiableInterface $item
     */
-   public function unpublishPolicy(PluginFlyvemdmNotifiable $item) {
+   public function unpublishPolicy(PluginFlyvemdmNotifiableInterface $item) {
       if ($this->silent) {
          return;
       }
@@ -586,10 +586,10 @@ class PluginFlyvemdmTask extends CommonDBRelation {
    /**
     * Removes persisted MQTT messages for groups of policies
     *
-    * @param PluginFlyvemdmNotifiable $item a notifiable item
+    * @param PluginFlyvemdmNotifiableInterface $item a notifiable item
     * @param array $groups array of groups to delete
     */
-   public static function cleanupPolicies(PluginFlyvemdmNotifiable $item, $groups = []) {
+   public static function cleanupPolicies(PluginFlyvemdmNotifiableInterface $item, $groups = []) {
       $mqttClient = PluginFlyvemdmMqttclient::getInstance();
       $topic = $item->getTopic();
       foreach ($groups as $groupName) {

--- a/install/installer.class.php
+++ b/install/installer.class.php
@@ -103,9 +103,6 @@ class PluginFlyvemdmInstaller {
       $this->migration = new Migration(PLUGIN_FLYVEMDM_VERSION);
       $this->migration->setVersion(PLUGIN_FLYVEMDM_VERSION);
 
-      // Load non-itemtype classes
-      require_once PLUGIN_FLYVEMDM_ROOT . '/inc/notifiable.class.php';
-
       // adding DB model from sql file
       // TODO : migrate in-code DB model setup here
       if (self::getCurrentVersion() == '') {

--- a/tests/suite-unit/PluginFlyvemdmPolicyBase.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBase.php
@@ -105,17 +105,17 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
    /**
     * @tags testApply
     */
-   public function testApply() {
+   public function testPre_apply() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->boolean($policy->apply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
+      $this->boolean($policy->pre_apply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
    }
 
    /**
     * @tags testUnapply
     */
-   public function testUnapply() {
+   public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->boolean($policy->unapply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
+      $this->boolean($policy->pre_unapply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
    }
 
    /**

--- a/tests/suite-unit/PluginFlyvemdmPolicyBase.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBase.php
@@ -107,7 +107,7 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
     */
    public function testPre_apply() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->boolean($policy->pre_apply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
+      $this->boolean($policy->pre_apply(null, null, null, new \PluginFlyvemdmFleet()))->isTrue();
    }
 
    /**
@@ -115,7 +115,7 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
     */
    public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->boolean($policy->pre_unapply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
+      $this->boolean($policy->pre_unapply(null, null, null, new \PluginFlyvemdmFleet()))->isTrue();
    }
 
    /**

--- a/tests/suite-unit/PluginFlyvemdmPolicyBase.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBase.php
@@ -52,7 +52,7 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
     */
    public function testCanApply() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->boolean($policy->canApply(new \PluginFlyvemdmFleet(), null, null, null))->isTrue();
+      $this->boolean($policy->canApply(null, null, null, new \PluginFlyvemdmFleet()))->isTrue();
    }
 
    /**

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
@@ -201,18 +201,18 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
       $appInDB = $this->createAppInDB();
 
       // check integrity
-      $this->boolean($policy->pre_unapply($mockInstance, null, null, null))->isFalse();
+      $this->boolean($policy->pre_unapply(null, null, null, $mockInstance))->isFalse();
 
       // check for task to delete
       $value = '{"remove_on_delete":0}';
       $packageClass = \PluginFlyvemdmPackage::class;
-      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
+      $this->boolean($policy->pre_unapply($value, $packageClass, $appInDB->getID(), $mockInstance))
          ->isTrue();
 
       $value = '{"remove_on_delete":1}';
-      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, -1))->isFalse();
+      $this->boolean($policy->pre_unapply($value, $packageClass, -1, $mockInstance))->isFalse();
       /*
-      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
+      $this->boolean($policy->pre_unapply($value, $packageClass, $appInDB->getID(), $mockInstance))
          ->isTrue(); // TODO: fix this, Cannot apply a policy on a not managed fleet
       */
    }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
@@ -194,25 +194,25 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
    /**
     * @tags testUnApply
     */
-   public function testUnApply() {
+   public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
       $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
       $mockInstance->getMockController()->getID = 1;
       $appInDB = $this->createAppInDB();
 
       // check integrity
-      $this->boolean($policy->unapply($mockInstance, null, null, null))->isFalse();
+      $this->boolean($policy->pre_unapply($mockInstance, null, null, null))->isFalse();
 
       // check for task to delete
       $value = '{"remove_on_delete":0}';
       $packageClass = \PluginFlyvemdmPackage::class;
-      $this->boolean($policy->unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
+      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
          ->isTrue();
 
       $value = '{"remove_on_delete":1}';
-      $this->boolean($policy->unapply($mockInstance, $value, $packageClass, -1))->isFalse();
+      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, -1))->isFalse();
       /*
-      $this->boolean($policy->unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
+      $this->boolean($policy->pre_unapply($mockInstance, $value, $packageClass, $appInDB->getID()))
          ->isTrue(); // TODO: fix this, Cannot apply a policy on a not managed fleet
       */
    }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
@@ -178,7 +178,7 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
     */
    public function testConflictCheck() {
       list($policy) = $this->createNewPolicyInstance();
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmFleet::class);
       $mockInstance->getMockController()->getID = 1;
       $packageClass = \PluginFlyvemdmPackage::class;
       $this->boolean($policy->conflictCheck(null, $packageClass, -1, $mockInstance))->isFalse();
@@ -196,7 +196,7 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
     */
    public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmFleet::class);
       $mockInstance->getMockController()->getID = 1;
       $appInDB = $this->createAppInDB();
 
@@ -244,7 +244,7 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
       list($policy) = $this->createNewPolicyInstance();
       $name = 'appName';
       $alias = 'appAlias';
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmTask');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmTask::class);
       $mockInstance->getMockController()->getField = 0;
       $mockInstance->getMockController()->getField[2] = 1;
       $mockInstance->getMockController()->getField[3] = $alias;

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
@@ -266,20 +266,20 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
    /**
     * @tags testUnApply
     */
-   public function testUnApply() {
+   public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
       $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
       $mockInstance->getMockController()->getID = 1;
       $fileInDb = $this->createFile();
 
-      $this->boolean($policy->unapply($mockInstance, null, null, null))->isFalse();
+      $this->boolean($policy->pre_unapply($mockInstance, null, null, null))->isFalse();
 
       $value = '{"destination":"%SDCARD%/filename.ext","remove_on_delete":0}';
-      $this->boolean($policy->unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
+      $this->boolean($policy->pre_unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
          $fileInDb->getID()))->isTrue();
 
       $value = '{"destination":"%SDCARD%/filename.ext","remove_on_delete":1}';
-      $this->boolean($policy->unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
+      $this->boolean($policy->pre_unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
          -1))->isFalse();
       // TODO: finish this test
    }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
@@ -272,15 +272,15 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
       $mockInstance->getMockController()->getID = 1;
       $fileInDb = $this->createFile();
 
-      $this->boolean($policy->pre_unapply($mockInstance, null, null, null))->isFalse();
+      $this->boolean($policy->pre_unapply(null, null, null, $mockInstance))->isFalse();
 
       $value = '{"destination":"%SDCARD%/filename.ext","remove_on_delete":0}';
-      $this->boolean($policy->pre_unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
-         $fileInDb->getID()))->isTrue();
+      $this->boolean($policy->pre_unapply($value, \PluginFlyvemdmFile::class,
+         $fileInDb->getID(), $mockInstance))->isTrue();
 
       $value = '{"destination":"%SDCARD%/filename.ext","remove_on_delete":1}';
-      $this->boolean($policy->pre_unapply($mockInstance, $value, \PluginFlyvemdmFile::class,
-         -1))->isFalse();
+      $this->boolean($policy->pre_unapply($value, \PluginFlyvemdmFile::class,
+         -1, $mockInstance))->isFalse();
       // TODO: finish this test
    }
 

--- a/tests/suite-unit/PluginFlyvemdmPolicyRemoveapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyRemoveapplication.php
@@ -153,34 +153,6 @@ class PluginFlyvemdmPolicyRemoveapplication extends CommonTestCase {
    }
 
    /**
-    * @dataProvider applyProvider
-    * @tags testApply
-    *
-    * @param array $data
-    * @param array $expected
-    */
-   public function testApply(array $data, array $expected) {
-      $policyData = null;
-      if (true === $expected['return']) {
-         $policyData = new \PluginFlyvemdmPolicy();
-         $policyData->getFromDBBySymbol('removeApp');
-      }
-      list($policy) = $this->createNewPolicyInstance($policyData);
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
-      $mockInstance->getMockController()->getID = 1;
-      if (true == $expected['return']) {
-         // the fleet must exist if we expect a true action.
-         $mockInstance = $this->createFleetInDB();
-      }
-      $result = $policy->apply($mockInstance, $data['value'], '', '');
-      $this->boolean($result)->isEqualTo($expected['return']);
-      if (!$expected['return'] && isset($expected['message'])) {
-         $this->string($_SESSION["MESSAGE_AFTER_REDIRECT"][1][0])->isEqualTo($expected['message']);
-      }
-      unset($_SESSION["MESSAGE_AFTER_REDIRECT"]); // to clear the buffer
-   }
-
-   /**
     * @tags testGetMqttMessage
     */
    public function testGetMqttMessage() {


### PR DESCRIPTION
I recommend reviewing this PR commit by commit

- drop useless code in remove app policy
- in consequence, rename appy / unapply into pre_apply / pre_unapply
- harmonize arguments of methods for policies
- append **Interface** at the end of PluginFlyvemdmNotifiable to harmonize with PluginFlyvemdmPolicyIntrerface