### PR TITLE
Fleet in  the root entity should not be recursive

### DIFF
--- a/install/installer.class.php
+++ b/install/installer.class.php
@@ -273,7 +273,7 @@ class PluginFlyvemdmInstaller {
          $fleet->add([
             'name'         => __('not managed fleet', 'flyvemdm'),
             'entities_id'  => '0',
-            'is_recursive' => '1',
+            'is_recursive' => '0',
             'is_default'   => '1',
          ]);
       }

--- a/tests/suite-install/Config.php
+++ b/tests/suite-install/Config.php
@@ -92,6 +92,14 @@ class Config extends CommonTestCase {
          'mqtt_broker_internal_address' => '127.0.0.1',
       ]);
 
+      $fleet = new \PluginFlyvemdmFleet();
+      $dbUtils = new \DBUtils();
+      $count = $dbUtils->countElementsInTable($fleet::getTable());
+      $this->integer($count)->isEqualTo(1);
+      $fleet->getFromDB(1);
+      $this->boolean($fleet->isNewItem())->isFalse();
+      $this->integer((int) $fleet->isRecursive())->isEqualTo(0);
+
       $config = \Config::getConfigurationValues('flyvemdm');
 
       // Test an agent's user profile exists


### PR DESCRIPTION
Reset the is_recursive flag to 0 when installing a default fleet in root entity