### PR TITLE
Fix invited devices are always created in root entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,11 @@
     "autoload-dev": {
         "psr-4": {
             "Flyvemdm\\Tests\\": "tests/src/Flyvemdm/Tests/",
-            "Glpi\\Tests\\": "tests/src/Glpi/Tests/"
+            "Glpi\\Tests\\": "tests/src/Glpi/Tests/",
+            "tests\\units\\": [
+               "tests/suite-unit/",
+               "tests/suite-integration/"
+            ]
         }
     }
 }

--- a/front/invitation.form.php
+++ b/front/invitation.form.php
@@ -55,6 +55,10 @@ if (isset($_POST['add'])) {
    $_POST['_notify'] = '';
    $invitation->update($_POST);
    Html::back();
+} else if (isset($_POST['purge'])) {
+   $invitation->check($_POST['id'], PURGE);
+   $invitation->delete($_POST, 1);
+   $invitation->redirectToList();
 } else {
    $invitation->check($_GET['id'], READ);
    Html::header(

--- a/hook.php
+++ b/hook.php
@@ -216,3 +216,12 @@ function plugin_flyvemdm_hook_computer_purge(CommonDBTM $item) {
    $agent = new PluginFlyvemdmAgent();
    $agent->hook_computer_purge($item);
 }
+
+function plugin_flyvemdm_hook_pre_invitation_purge(CommonDBTM $item) {
+   $success = true;
+
+   $invitation = new PluginFlyvemdmInvitation();
+   $success = $success && $invitation->hook_pre_invitation_purge($item);
+
+   return $success;
+}

--- a/inc/exception/fusioninventoryruleinconsistency.class.php
+++ b/inc/exception/fusioninventoryruleinconsistency.class.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace GlpiPlugin\Flyvemdm\Exception;
+
+
+class FusionInventoryRuleInconsistency extends \Exception {}

--- a/inc/fusioninventory.class.php
+++ b/inc/fusioninventory.class.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * LICENSE
+ *
+ * Copyright © 2016-2018 Teclib'
+ * Copyright © 2010-2018 by the FusionInventory Development Team.
+ *
+ * This file is part of Flyve MDM Plugin for GLPI.
+ *
+ * Flyve MDM Plugin for GLPI is a subproject of Flyve MDM. Flyve MDM is a mobile
+ * device management software.
+ *
+ * Flyve MDM Plugin for GLPI is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Flyve MDM Plugin for GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Flyve MDM Plugin for GLPI. If not, see http://www.gnu.org/licenses/.
+ * ------------------------------------------------------------------------------
+ * @author    Thierry Bugier
+ * @copyright Copyright © 2018 Teclib
+ * @license   AGPLv3+ http://www.gnu.org/licenses/agpl.txt
+ * @link      https://github.com/flyve-mdm/glpi-plugin
+ * @link      https://flyve-mdm.com/
+ * ------------------------------------------------------------------------------
+ */
+
+ use GlpiPlugin\Flyvemdm\Exception\FusionInventoryRuleInconsistency;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+class PluginFlyvemdmFusionInventory {
+
+   const RULE_NAME = 'Flyve MDM invitation to entity';
+
+   /**
+    * Creates or updates an entity rule
+    *
+    * @param PluginFlyvemdmInvitation $invitation invitation to handle
+    */
+   public function addInvitationRule(PluginFlyvemdmInvitation $invitation) {
+      $entityId = $invitation->getField(Entity::getForeignKeyField());
+      $rule = $this->getRule($entityId);
+
+      $ruleCriteria = new RuleCriteria();
+      $ruleCriteria->add([
+         Rule::getForeignKeyField() => $rule->getID(),
+         'criteria'                 => 'tag',
+         'condition'                => '0',
+         'pattern'                  => $this->getRuleCriteriaValue($invitation),
+      ]);
+
+      // Activate the rule
+      $rule->update([
+         'id'        => $rule->getID(),
+         'is_active' => '1',
+      ]);
+   }
+
+   /**
+    * Deletes a rule criteria for an entity assignment rule
+    *
+    * @param PluginFlyvemdmInvitation $invitation invitation to handle
+    */
+   public function deleteInvitationRuleCriteria(PluginFlyvemdmInvitation $invitation) {
+      global $DB;
+
+      $entityId = $invitation->getField(Entity::getForeignKeyField());
+      $ruleFk = PluginFusioninventoryInventoryRuleEntity::getForeignKeyField();
+      $request = [
+         'SELECT' => RuleCriteria::getTable() . '.*',
+         'FROM' => RuleCriteria::getTable(),
+         'INNER JOIN' => [
+            PluginFusioninventoryInventoryRuleEntity::getTable() => [
+               'FKEY' => [
+                  PluginFusioninventoryInventoryRuleEntity::getTable() => 'id',
+                  RuleCriteria::getTable() => $ruleFk,
+               ]
+            ],
+            RuleAction::getTable() => [
+               'FKEY' => [
+                  PluginFusioninventoryInventoryRuleEntity::getTable() => 'id',
+                  RuleAction::getTable() => $ruleFk,
+               ]
+            ]
+         ],
+         'WHERE' => [
+            'AND' => [
+               'pattern'   => $this->getRuleCriteriaValue($invitation),
+               'criteria'  => 'tag',
+            ]
+         ]
+      ];
+      $result = $DB->request($request);
+      if ($result->count() !== 1) {
+         return;
+      }
+
+      $row = $result->next();
+      $ruleCriteria = new RuleCriteria();
+      $ruleCriteria->delete([
+         'id' => $row['id']
+      ]);
+
+      $ruleId = $row[$ruleFk];
+      $rows = $ruleCriteria->find("`$ruleFk` = '$ruleId' AND `criteria` = 'tag' AND `condition` = '0'");
+      if (count($rows) === 0) {
+         $rule = new PluginFusioninventoryInventoryRuleEntity();
+         $rule->update([
+            'id' => $row[$ruleFk],
+            'is_active' => '0',
+         ]);
+      }
+   }
+
+   /**
+    * gets a entity identification tag derivated from an invitation
+    */
+   private function getRuleCriteriaValue(PluginFlyvemdmInvitation $invitation) {
+      return 'invitation_' . $invitation->getField('invitation_token');
+   }
+
+   /**
+    * Finds a rule
+    *
+    * @param integer $entityId ID of the entity assigned by the rule
+    * @param boolean $create If the rule does not exists, create it
+    *
+    * @return PluginFusioninventoryInventoryRuleEntity|null
+    */
+   private function getRule($entityId, $create = true) {
+      global $DB;
+
+      $request = [
+         'SELECT' => PluginFusioninventoryInventoryRuleEntity::getTable() . '.*',
+         'FROM' => PluginFusioninventoryInventoryRuleEntity::getTable(),
+         'INNER JOIN' => [
+            RuleAction::getTable() => [
+               'FKEY' => [
+                  PluginFusioninventoryInventoryRuleEntity::getTable() => 'id',
+                  RuleAction::getTable() => PluginFusioninventoryInventoryRuleEntity::getForeignKeyField()
+               ],
+            ]
+         ],
+         'WHERE'  => [
+            'AND' => [
+               PluginFusioninventoryInventoryRuleEntity::getTable() . '.name'
+                  => self::RULE_NAME . " $entityId",
+               'sub_type'     => PluginFusioninventoryInventoryRuleEntity::class,
+               'action_type'  => 'assign',
+               'field'        => Entity::getForeignKeyField(),
+               'value'        => $entityId,
+            ]
+         ]
+      ];
+
+      $result = $DB->request($request);
+      if ($result->count() === 1) {
+         $rule = new PluginFusioninventoryInventoryRuleEntity();
+         $row = $result->next();
+         $rule->getFromDB($row['id']);
+         return $rule;
+      }
+      if ($result->count() > 1) {
+         throw new FusionInventoryRuleInconsistency('Import to entity rule is not unique');
+      }
+
+      if (!$create) {
+         return null;
+      }
+
+      $rule = new PluginFusioninventoryInventoryRuleEntity();
+      $rule->add([
+         'sub_type'     => PluginFusioninventoryInventoryRuleEntity::class,
+         'entities_id'  => '0',
+         'is_recursive' => '0',
+         'name'         => self::RULE_NAME . " $entityId",
+         'description'  => 'Automatically generated by an invitation to enrol. Do not change its name',
+         'is_active'    => '0',
+         'condition'    => '0',
+         'match'        => Rule::OR_MATCHING,
+      ]);
+      $ruleAction = new RuleAction();
+      $ruleAction->add([
+         Rule::getForeignKeyField() => $rule->getID(),
+         'action_type'              => 'assign',
+         'field'                    => Entity::getForeignKeyField(),
+         'value'                    => $entityId,
+      ]);
+      return $rule;
+   }
+}

--- a/inc/invitation.class.php
+++ b/inc/invitation.class.php
@@ -244,6 +244,21 @@ class PluginFlyvemdmInvitation extends CommonDBTM {
       $this->sendInvitation();
    }
 
+   public function post_updateItem($history = 1) {
+      // Update the dynamic import entity rules
+      if (in_array('status', $this->updates)) {
+         $fi = new PluginFlyvemdmFusionInventory();
+         switch ($this->fields['status']) {
+            case  'done':
+               $fi->deleteInvitationRuleCriteria($this);
+               break;
+            case 'pending':
+               $fi->addInvitationRule($this);
+               break;
+         }
+      }
+   }
+
    /**
     * @see CommonDBTM::pre_deleteItem()
     * @param CommonDBTM $item

--- a/inc/invitation.class.php
+++ b/inc/invitation.class.php
@@ -227,20 +227,20 @@ class PluginFlyvemdmInvitation extends CommonDBTM {
       return $token;
    }
 
-   /**
-    *
-    * @see CommonDBTM::pre_deleteItem()
-    */
    public function pre_deleteItem() {
       $invitationLog = new PluginFlyvemdmInvitationlog();
       return $invitationLog->deleteByCriteria(['plugin_flyvemdm_invitations_id' => $this->getID()]);
    }
 
-   /**
-    * @see CommonDBTM::post_addItem()
-    */
    public function post_addItem() {
+      // Create / update import to entity rule
+      $fi = new PluginFlyvemdmFusionInventory();
+      $fi->addInvitationRule($this);
+
+      // Generate QR code
       $this->createQRCodeDocument();
+
+      // Sent invitation email
       $this->sendInvitation();
    }
 
@@ -249,9 +249,10 @@ class PluginFlyvemdmInvitation extends CommonDBTM {
     * @param CommonDBTM $item
     * @return bool
     */
-   public static function hook_pre_self_purge(CommonDBTM $item) {
+   public function hook_pre_invitation_purge(CommonDBTM $item) {
+      $fi = new PluginFlyvemdmFusionInventory();
+      $fi->deleteInvitationRuleCriteria($item);
       $document = new Document();
-      $document->getFromDB($item->getField('documents_id'));
       return $document->delete([
          'id' => $item->getField('documents_id'),
       ], 1);

--- a/setup.php
+++ b/setup.php
@@ -170,7 +170,7 @@ function plugin_flyvemdm_addHooks() {
       Computer::class                  => 'plugin_flyvemdm_hook_computer_purge',
    ];
    $PLUGIN_HOOKS['pre_item_purge']['flyvemdm']   = [
-      PluginFlyvemdmInvitation::class => [PluginFlyvemdmInvitation::class, 'hook_pre_self_purge'],
+      PluginFlyvemdmInvitation::class => 'plugin_flyvemdm_hook_pre_invitation_purge',
       Document::class                 => [PluginFlyvemdmInvitation::class, 'hook_pre_document_purge'],
       Profile_User::class             => 'plugin_flyvemdm_hook_pre_profileuser_purge',
    ];

--- a/tests/suite-unit/PluginFlyvemdmFusionInventory.php
+++ b/tests/suite-unit/PluginFlyvemdmFusionInventory.php
@@ -49,20 +49,8 @@ class PluginFlyvemdmFusionInventory extends CommonTestCase {
       $fi->addInvitationRule($invitation);
 
       // Test a rule exists for the entity
-      $entityId = $invitation->fields[\Entity::getForeignKeyField()];
-      $row = $this->findRuleForEntity($entityId);
-
-      // Test the rule criteria for the invitation exists
-      $ruleCriteria = new \RuleCriteria();
-      $ruleCriteria->getFromDBByCrit([
-         'AND' => [
-            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
-            'criteria'  => 'tag',
-            'condition' => '0',
-            'pattern'   => 'invitation_' . $invitation->fields['invitation_token'],
-         ]
-      ]);
-      $this->boolean($ruleCriteria->isNewItem())->isFalse();
+      $this->checkRuleAndCriteria($invitation);
+      $row = $this->findRuleForEntity($invitation->fields[\Entity::getForeignKeyField()]);
 
       $ruleAction = new \RuleAction();
       $ruleAction->getFromDbByCrit([
@@ -175,5 +163,28 @@ class PluginFlyvemdmFusionInventory extends CommonTestCase {
       $result = $DB->request($request);
       $this->integer($result->count())->isEqualTo(1);
       return $result->next();
+   }
+
+   /**
+    * Checks a rule exists and matches an invitation
+    *
+    * @param \PluginFlyvemdmInvitation $invitation invitation to  check
+    * @param boolean $hasCriteria true if it is expeccted the criteria exists
+    */
+   public function checkRuleAndCriteria(\PluginFlyvemdmInvitation $invitation, $hasCriteria = true) {
+      $entityId = $invitation->fields[\Entity::getForeignKeyField()];
+      $row = $this->findRuleForEntity($entityId);
+
+      // Test the rule criteria for the invitation exists
+      $ruleCriteria = new \RuleCriteria();
+      $ruleCriteria->getFromDBByCrit([
+         'AND' => [
+            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
+            'criteria'  => 'tag',
+            'condition' => '0',
+            'pattern'   => 'invitation_' . $invitation->fields['invitation_token'],
+         ]
+      ]);
+      $this->boolean($ruleCriteria->isNewItem())->isEqualTo(!$hasCriteria);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmFusionInventory.php
+++ b/tests/suite-unit/PluginFlyvemdmFusionInventory.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * LICENSE
+ *
+ * Copyright © 2016-2018 Teclib'
+ * Copyright © 2010-2018 by the FusionInventory Development Team.
+ *
+ * This file is part of Flyve MDM Plugin for GLPI.
+ *
+ * Flyve MDM Plugin for GLPI is a subproject of Flyve MDM. Flyve MDM is a mobile
+ * device management software.
+ *
+ * Flyve MDM Plugin for GLPI is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Flyve MDM Plugin for GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Flyve MDM Plugin for GLPI. If not, see http://www.gnu.org/licenses/.
+ * ------------------------------------------------------------------------------
+ * @author    Thierry Bugier
+ * @copyright Copyright © 2018 Teclib
+ * @license   AGPLv3+ http://www.gnu.org/licenses/agpl.txt
+ * @link      https://github.com/flyve-mdm/glpi-plugin
+ * @link      https://flyve-mdm.com/
+ * ------------------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Flyvemdm\Tests\CommonTestCase;
+
+class PluginFlyvemdmFusionInventory extends CommonTestCase {
+
+   /**
+    * Run without concurrency, becauase it tests an inconsistency in DB
+    * @engine inline
+    */
+   public function testAddInvitationRule() {
+      // Create an invitation
+      $invitation = $this->newMockInstance(\PluginFlyvemdmInvitation::class);
+      $invitation->fields['invitation_token'] = $this->getUniqueString();
+      $invitation->fields[\Entity::getForeignKeyField()] = 1;
+
+      $fi = new \PluginFlyvemdmFusionInventory();
+      $fi->addInvitationRule($invitation);
+
+      // Test a rule exists for the entity
+      $entityId = $invitation->fields[\Entity::getForeignKeyField()];
+      $row = $this->findRuleForEntity($entityId);
+
+      // Test the rule criteria for the invitation exists
+      $ruleCriteria = new \RuleCriteria();
+      $ruleCriteria->getFromDBByCrit([
+         'AND' => [
+            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
+            'criteria'  => 'tag',
+            'condition' => '0',
+            'pattern'   => 'invitation_' . $invitation->fields['invitation_token'],
+         ]
+      ]);
+      $this->boolean($ruleCriteria->isNewItem())->isFalse();
+
+      $ruleAction = new \RuleAction();
+      $ruleAction->getFromDbByCrit([
+         'AND' => [
+            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
+            'action_type'  => 'assign',
+            'field'        => \Entity::getForeignKeyField(),
+            'value'        => $invitation->getField(\Entity::getForeignKeyField()),
+         ]
+      ]);
+      $this->boolean($ruleAction->isNewItem())->isFalse();
+
+      // Test an exception is thrown in case of inconsistency
+      $input = $row;
+      unset($input['id']);
+      $rule = new \PluginFusioninventoryInventoryRuleEntity();
+      $rule->add($input);
+      $input = $ruleAction->fields;
+      $input[\PluginFusioninventoryInventoryRuleEntity::getForeignKeyField()] = $rule->getID();
+      unset($input['id']);
+      $ruleAction->add($input);
+      $this->exception(
+         function() use ($fi, $invitation) {
+            $fi->addInvitationRule($invitation);
+         }
+      );
+
+      // Cleanup inconsistency in DB
+      $ruleAction->delete(['id' => $ruleAction->getID()]);
+
+      $this->object($this->exception)->isInstanceOf(\GlpiPlugin\Flyvemdm\Exception\FusionInventoryRuleInconsistency::class);
+      $this->string($this->exception->getMessage())->isEqualTo('Import to entity rule is not unique');
+
+      // Create an invitation again
+      $invitation = $this->newMockInstance(\PluginFlyvemdmInvitation::class);
+      $invitation->fields['invitation_token'] = $this->getUniqueString();
+      $invitation->fields[\Entity::getForeignKeyField()] = 1;
+
+      $fi = new \PluginFlyvemdmFusionInventory();
+      $fi->addInvitationRule($invitation);
+
+      // Test the rule criteria for the invitation exists
+      // and uses the same rule as the previous invitation
+      $ruleCriteria = new \RuleCriteria();
+      $ruleCriteria->getFromDBByCrit([
+         'AND' => [
+            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
+            'criteria'  => 'tag',
+            'condition' => '0',
+            'pattern'   => 'invitation_' . $invitation->fields['invitation_token'],
+         ]
+      ]);
+      $this->boolean($ruleCriteria->isNewItem())->isFalse();
+   }
+
+   public function testDeleteInvitationRuleCriteria() {
+      // Create an invitation
+      $invitation = $this->newMockInstance(\PluginFlyvemdmInvitation::class);
+      $invitation->fields['invitation_token'] = $this->getUniqueString();
+      $invitation->fields[\Entity::getForeignKeyField()] = 1;
+
+      $fi = new \PluginFlyvemdmFusionInventory();
+      $fi->addInvitationRule($invitation);
+      $entityId = $invitation->fields[\Entity::getForeignKeyField()];
+      $row = $this->findRuleForEntity($entityId);
+
+      //  Test the rule criteria for the invitation exists
+      $ruleCriteria = new \RuleCriteria();
+      $ruleCriteria->getFromDBByCrit([
+         'AND' => [
+            \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField() => $row['id'],
+            'criteria'  => 'tag',
+            'condition' => '0',
+            'pattern'   => 'invitation_' . $invitation->fields['invitation_token'],
+         ]
+      ]);
+      $this->boolean($ruleCriteria->isNewItem())->isFalse();
+
+      $fi->deleteInvitationRuleCriteria($invitation);
+      $found = $ruleCriteria->getFromDB($ruleCriteria->getID());
+      $this->boolean($found)->isFalse();
+   }
+
+   private function findRuleForEntity($entityId) {
+      global $DB;
+
+      $request = [
+         'SELECT' => \PluginFusioninventoryInventoryRuleEntity::getTable() . '.*',
+         'FROM' => \PluginFusioninventoryInventoryRuleEntity::getTable(),
+         'INNER JOIN' => [
+            \RuleAction::getTable() => [
+               'FKEY' => [
+                  \PluginFusioninventoryInventoryRuleEntity::getTable() => 'id',
+                  \RuleAction::getTable() => \PluginFusioninventoryInventoryRuleEntity::getForeignKeyField()
+               ],
+            ]
+         ],
+         'WHERE'  => [
+            'AND' => [
+               \PluginFusioninventoryInventoryRuleEntity::getTable() . '.name'
+                  => \PluginFlyvemdmFusionInventory::RULE_NAME . " $entityId",
+               'sub_type'     => \PluginFusioninventoryInventoryRuleEntity::class,
+               'action_type'  => 'assign',
+               'field'        => \Entity::getForeignKeyField(),
+               'value'        => $entityId,
+            ]
+         ]
+      ];
+
+      $result = $DB->request($request);
+      $this->integer($result->count())->isEqualTo(1);
+      return $result->next();
+   }
+}

--- a/tests/suite-unit/PluginFlyvemdmInvitation.php
+++ b/tests/suite-unit/PluginFlyvemdmInvitation.php
@@ -43,6 +43,7 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
          case 'testShowForm':
          case 'testPrepareInputForAdd':
          case 'testPrepareInputForUpdate':
+         case 'testPost_updateItem':
             $this->login('glpi', 'glpi');
             break;
       }
@@ -207,5 +208,24 @@ class PluginFlyvemdmInvitation extends CommonTestCase {
          ->contains("input type='hidden' name='entities_id' value='0'")
          ->contains('input name="_useremails" value=""')
          ->contains('input type="hidden" name="_glpi_csrf_token"');
+   }
+
+   public function testPost_updateItem() {
+      $instance = $this->newTestedInstance();
+      $instance->add([
+         '_useremails' => 'someone@localhost.local',
+         'entities_id' => 0,
+      ]);
+
+      $this->boolean($instance->isNewItem())->isFalse();
+      $testFusionInventory = new PluginFlyvemdmFusionInventory();
+      $testFusionInventory->checkRuleAndCriteria($instance);
+
+      $instance->update([
+         'id'     => $instance->getID(),
+         'status' => 'done',
+      ]);
+
+      $testFusionInventory->checkRuleAndCriteria($instance, false);
    }
 }


### PR DESCRIPTION
Automatically generate rules to "route" imported devices in the entity of  the invitation.

@rafaelje the tag in  the inventory must be similar to **invitation_4564546564587**.

I'm unsure how I described you the tag on telegram (underscore or dash). We need to check and use the same !