### PR TITLE
Remove obsolete requirements

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1087,8 +1087,6 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
 
       $invitationToken  = isset($input['_invitation_token']) ? $input['_invitation_token'] : null;
       $email            = isset($input['_email']) ? $input['_email'] : null;
-      $serial           = isset($input['_serial']) ? $input['_serial'] : null;
-      $uuid             = isset($input['_uuid']) ? $input['_uuid'] : null;
       $csr              = isset($input['csr']) ? $input['csr'] : null;
       $firstname        = isset($input['firstname']) ? $input['firstname'] : null;
       $lastname         = isset($input['lastname']) ? $input['lastname'] : null;
@@ -1115,13 +1113,6 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
       $invitation = new PluginFlyvemdmInvitation();
       if (!$invitation->getFromDBByToken($invitationToken)) {
          $this->filterMessages(__('Invitation token invalid', 'flyvemdm'));
-         return false;
-      }
-
-      if (empty($serial) && empty($uuid)) {
-         $event = __('One of serial and uuid is mandatory', 'flyvemdm');
-         $this->filterMessages($event);
-         $this->logInvitationEvent($invitation, $event);
          return false;
       }
 
@@ -1334,7 +1325,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
       $agentAccount->add([
          'usercategories_id' => $config['agentusercategories_id'],
          'name'              => 'flyvemdm-' . PluginFlyvemdmCommon::generateUUID(),
-         'realname'          => $serial,
+         'realname'          => $computer->getField('serial'),
          '_profiles_id'      => $config['agent_profiles_id'],
          'profiles_id'       => $config['agent_profiles_id'],      // Default profile when user logs in
          '_entities_id'      => $entityId,

--- a/tests/suite-integration/PluginFlyvemdmAgent.php
+++ b/tests/suite-integration/PluginFlyvemdmAgent.php
@@ -42,7 +42,6 @@ class PluginFlyvemdmAgent extends CommonTestCase {
    protected $computerTypeId = 3;
 
    public function setUp() {
-      $this->resetState();
       \Config::setConfigurationValues('flyvemdm', ['computertypes_id' => $this->computerTypeId]);
    }
 
@@ -64,11 +63,16 @@ class PluginFlyvemdmAgent extends CommonTestCase {
 
    public function afterTestMethod($method) {
       parent::afterTestMethod($method);
+      switch ($method) {
+         case 'testInvalidEnrollAgent':
+            // Enable debug mode for enrollment messages
+            \Config::setConfigurationValues(TEST_PLUGIN_NAME, ['debug_enrolment' => '1']);
+            break;
+      }
    }
 
    /**
     * @tags testDeviceCountLimit
-    * @engine inline
     */
    public function testDeviceCountLimit() {
       $entity = new \Entity();

--- a/tests/suite-integration/PluginFlyvemdmAgent.php
+++ b/tests/suite-integration/PluginFlyvemdmAgent.php
@@ -51,6 +51,11 @@ class PluginFlyvemdmAgent extends CommonTestCase {
       $this->setupGLPIFramework();
       $this->boolean($this->login('glpi', 'glpi'))->isTrue();
       switch ($method) {
+         case 'testInvalidEnrollAgent':
+            // Enable debug mode for enrollment messages
+            \Config::setConfigurationValues(TEST_PLUGIN_NAME, ['debug_enrolment' => '1']);
+            break;
+
          case 'testDeviceCountLimit':
             \Session::changeActiveEntities(1, true);
             break;
@@ -110,10 +115,9 @@ class PluginFlyvemdmAgent extends CommonTestCase {
 
       // reset config for other tests
       $entityConfig->update(['id' => $activeEntity, 'device_limit' => '0']);
-      //\Session::destroy();
    }
 
-   protected function invalidEnrollmentDataProvider() {
+   protected function providerInvalidEnrollAgent() {
       $version = \PluginFlyvemdmAgent::MINIMUM_ANDROID_VERSION . '.0';
       $serial = $this->getUniqueString();
       $inventory = base64_decode(self::AgentXmlInventory($serial));
@@ -150,12 +154,6 @@ class PluginFlyvemdmAgent extends CommonTestCase {
             ],
             'expected' => 'The agent version is too low',
          ],
-         'without serial or uuid' => [
-            'data'     => [
-               'serial'      => null,
-            ],
-            'expected' => 'One of serial and uuid is mandatory',
-         ],
          'without inventory'      => [
             'data'     => [
                'version'     => $version,
@@ -175,7 +173,7 @@ class PluginFlyvemdmAgent extends CommonTestCase {
    }
 
    /**
-    * @dataProvider invalidEnrollmentDataProvider
+    * @dataProvider providerInvalidEnrollAgent
     * @tags testInvalidEnrollAgent
     * @param array $data
     * @param string $expected
@@ -218,7 +216,6 @@ class PluginFlyvemdmAgent extends CommonTestCase {
       list($user, $serial, $guestEmail, $invitation) = $this->createUserInvitation(\User::getForeignKeyField());
       $invitationToken = $invitation->getField('invitation_token');
       $inviationId = $invitation->getID();
-
       // Test successful enrollment
       $agent = $this->agentFromInvitation($user, $guestEmail, $serial, $invitationToken, 'apple');
       $this->boolean($agent->isNewItem())


### PR DESCRIPTION
Serial and uuid are no longer used in enrolment. These data are in the inventory and the creation of the computer is delegated to this plugin. 