### PR TITLE
Move and reverse unknown sources policy

### DIFF
--- a/install/policies/deployment.php
+++ b/install/policies/deployment.php
@@ -101,4 +101,21 @@ return [
       'is_android_system'                   => '0',
       'is_apple_policy'                     => '0',
    ],
+
+   [
+      'name'                                => __('Disable unknown sources', 'flyvemdm'),
+      'symbol'                              => 'disableUnknownAppSources',
+      'group'                               => 'phone',
+      'type'                                => 'bool',
+      'type_data'                           => '',
+      'unicity'                             => 1,
+      'plugin_flyvemdm_policycategories_id' => $category,
+      'comment'                             => __('Disable installation of apps from unknown sources',
+         'flyvemdm'),
+      'default_value'                       => '0',
+      'recommended_value'                   => '0',
+      'is_android_policy'                   => '1',
+      'is_android_system'                   => '1',
+      'is_apple_policy'                     => '0',
+   ],
 ];

--- a/install/policies/phone.php
+++ b/install/policies/phone.php
@@ -50,21 +50,4 @@ return [
       'is_android_system'                   => '1',
       'is_apple_policy'                     => '0',
    ],
-
-   [
-      'name'                                => __('Enable unknown sources', 'flyvemdm'),
-      'symbol'                              => 'unknownAppSources',
-      'group'                               => 'phone',
-      'type'                                => 'bool',
-      'type_data'                           => '',
-      'unicity'                             => 1,
-      'plugin_flyvemdm_policycategories_id' => $category,
-      'comment'                             => __('Allow installation of apps from unknown sources',
-         'flyvemdm'),
-      'default_value'                       => '0',
-      'recommended_value'                   => '0',
-      'is_android_policy'                   => '1',
-      'is_android_system'                   => '1',
-      'is_apple_policy'                     => '0',
-   ],
 ];


### PR DESCRIPTION
The policy was in the bad category, and it is better to disallow unknown sources with the same mechanism as disable Bluetooth.

- if Disable Unknown Sources is applied with the value *Yes** then the agent must forbid the user from enabling unknown sources
- if Disable Unknown Sources is applied with the value **No**  then the agent must do nothing (allowing the user to freely enable or disable the unknown sources)
- if Disable Unknown Sources is not applied,  then the agent must do nothing  (allowing the user to freely enable or disable the unknown sources)