### PR TITLE
Reorder cascaded task creation

### DIFF
--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -70,6 +70,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
 
     /**
      * get common task statuses
+     *
      * @return array
      */
    public static final function getEnumBaseTaskStatus() {
@@ -91,6 +92,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     /**
      * get specific task statuses
      * To be overriden in child class
+     *
      * @return array
      */
    public static function getEnumSpecificStatus() {
@@ -109,6 +111,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * JSON decode properties for the policy and merges them with default values
     * @param string $properties
     * @param array $defaultProperties
+    *
     * @return array
     */
    protected function jsonDecodeProperties($properties, array $defaultProperties) {
@@ -130,6 +133,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmNotifiableInterface $notifiable
+    *
     * @return bool
     */
    public function canApply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
@@ -141,6 +145,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmNotifiableInterface $notifiable
+    *
     * @return boolean
     */
    public function unicityCheck($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
@@ -161,6 +166,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmNotifiableInterface $notifiable
+    *
     * @return boolean
     */
    public function conflictCheck($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
@@ -171,6 +177,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
+    *
     * @return bool
     */
    public function integrityCheck($value, $itemtype, $itemId) {
@@ -195,8 +202,9 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $value
     * @param mixed $itemtype
     * @param integer $itemId
-    * @return bool
     * @param PluginFlyvemdmNotifiableInterface $notifiable
+    *
+    * @return bool
     */
    public function pre_apply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
       return true;
@@ -207,6 +215,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @param mixed $itemtype
     * @param integer $itemId
     * @param PluginFlyvemdmNotifiableInterface $notifiable
+    *
     * @return bool
     */
    public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
@@ -216,9 +225,18 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
    }
 
    /**
+    * @param mixed $value
+    * @param mixed $itemtype
+    * @param integer $itemId
+    * @param PluginFlyvemdmNotifiableInterface $notifiable
+    */
+   public function post_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {}
+
+   /**
     * @param string $value value of the task
     * @param string $itemType type of the item linked to the task
     * @param integer $itemId ID of the item
+    *
     * @return string
     */
    public function showValueInput($value = '', $itemType = '', $itemId = 0) {
@@ -229,6 +247,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
 
    /**
     * @param PluginFlyvemdmTask $task
+    *
     * @return mixed
     */
    public function showValue(PluginFlyvemdmTask $task) {
@@ -237,6 +256,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
 
    /**
     * @param array $input
+    *
     * @return array
     */
    public function preprocessFormData($input) {
@@ -245,6 +265,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
 
    /**
     * @param $status
+    *
     * @return mixed
     */
    public function filterStatus($status) {
@@ -268,6 +289,7 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     *
     * @param string $mode add or update
     * @param array $_input values for update
+    *
     * @return string html
     */
    public function formGenerator(

--- a/inc/policydeployapplication.class.php
+++ b/inc/policydeployapplication.class.php
@@ -38,6 +38,9 @@ if (!defined('GLPI_ROOT')) {
  */
 class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface {
 
+   /** @var array $postUnapplyTask task to add after unapplying the policy */
+   private $postUnapplyTask = null;
+
    /**
     * PluginFlyvemdmPolicyDeployapplication constructor.
     * @param PluginFlyvemdmPolicy $policy
@@ -208,17 +211,19 @@ class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase imp
          return false;
       }
 
-      $task = new PluginFlyvemdmTask();
-      if (!$task->add([
+      $this->postUnapplyTask = [
          'itemtype_applied'            => $notifiable->getType(),
          'items_id_applied'            => $notifiable->getID(),
          'plugin_flyvemdm_policies_id' => $policyData->getID(),
          'value'                       => $package->getField('package_name'),
-      ])) {
-         return false;
-      }
+      ];
 
       return true;
+   }
+
+   public function post_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
+      $task = new PluginFlyvemdmTask();
+      $task->add($this->postUnapplyTask);
    }
 
    public function showValueInput($value = '', $itemType = '', $itemId = 0) {

--- a/inc/policydeployfile.class.php
+++ b/inc/policydeployfile.class.php
@@ -38,6 +38,9 @@ if (!defined('GLPI_ROOT')) {
  */
 class PluginFlyvemdmPolicyDeployfile extends PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface {
 
+   /** @var array $postUnapplyTask task to add after unapplying the policy */
+   private $postUnapplyTask = null;
+
    /**
     * @param PluginFlyvemdmPolicy $policy
     * @internal param string $properties
@@ -240,16 +243,20 @@ class PluginFlyvemdmPolicyDeployfile extends PluginFlyvemdmPolicyBase implements
       if (strrpos($value['destination'], '/') != strlen($value['destination']) - 1) {
          $value['destination'] .= '/';
       }
-      if (!$task->add([
+
+      $this->postUnapplyTask = [
          'itemtype_applied'            => $notifiable->getType(),
          'items_id_applied'            => $notifiable->getID(),
          'plugin_flyvemdm_policies_id' => $policyData->getID(),
          'value'                       => $value['destination'] . $file->getField('name'),
-      ])) {
-         return false;
-      }
+      ];
 
       return true;
+   }
+
+   public function post_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable) {
+      $task = new PluginFlyvemdmTask();
+      $task->add($this->postUnapplyTask);
    }
 
    /**

--- a/inc/policyinterface.class.php
+++ b/inc/policyinterface.class.php
@@ -114,7 +114,7 @@ interface PluginFlyvemdmPolicyInterface {
    public function pre_apply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable);
 
    /**
-    * Actions done after a policy is unapplied to a notifiable
+    * Actions done before a policy is unapplied to a notifiable
     *
     * @param mixed $value
     * @param mixed $itemtype
@@ -124,6 +124,16 @@ interface PluginFlyvemdmPolicyInterface {
    public function pre_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable);
 
    /**
+    * Actions done after a policy is unapplied to a notifiable
+    *
+    * @param mixed $value
+    * @param mixed $itemtype
+    * @param integer $itemId
+    * @param PluginFlyvemdmNotifiableInterface $notifiable
+    */
+   public function post_unapply($value, $itemtype, $itemId, PluginFlyvemdmNotifiableInterface $notifiable);
+
+    /**
     * return HTML input to set policy value
     * @param string $value value of the task
     * @param string $itemType type of the item linked to the task

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -261,7 +261,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
          $itemId = $input['items_id'];
       }
 
-      //Check the fleet exists
+      //Check the notifiable exists
       $notifiableType = $this->fields['itemtype_applied'];
       $notifiableId = $this->fields['items_id_applied'];
       if (isset($input['items_id_applied'])) {
@@ -283,7 +283,7 @@ class PluginFlyvemdmTask extends CommonDBRelation {
          return false;
       }
 
-      // Check the policy may be applied to the fleet and the value is matches requirements
+      // Check the policy may be applied to the notifiable and the value matches requirements
       if (!$this->policy->integrityCheck($value, $itemtype, $itemId)) {
          Session::addMessageAfterRedirect(__('Incorrect value for this policy', 'flyvemdm'), false,
             ERROR);
@@ -347,9 +347,10 @@ class PluginFlyvemdmTask extends CommonDBRelation {
     * @see CommonDBTM::post_deleteItem()
     */
    public function post_purgeItem() {
-      //$this->updateQueue($this->notifiable, [$this->policy->getGroup()]);
       $this->unpublishPolicy($this->notifiable);
       $this->deleteTaskStatuses();
+      $this->policy->post_unapply($this->fields['value'], $this->fields['itemtype'],
+         $this->fields['items_id'], $this->notifiable);
    }
 
    /**

--- a/tests/src/Flyvemdm/Tests/CommonTestCase.php
+++ b/tests/src/Flyvemdm/Tests/CommonTestCase.php
@@ -537,7 +537,7 @@ class CommonTestCase extends GlpiCommonTestCase {
          'Policy/disableSpeakerphone',
          'Policy/disableCreateVpnProfiles',
          'Policy/inventoryFrequency',
-         'Policy/unknownAppSources',
+         'Policy/disableUnknownAppSources',
       ];
    }
 }


### PR DESCRIPTION
For application / file deployment tasls.

When the administrator unapplies an app / file deployment task, and this task has remove_on_delete set, the delete app / file task must send its MQTT message **after** the null MQTT message

### before

![image](https://user-images.githubusercontent.com/14139801/39913307-af3b36e4-5501-11e8-9bd6-1605738dced9.png)

### after
![image](https://user-images.githubusercontent.com/14139801/39913294-a15aaa46-5501-11e8-8559-ff850ea3d4ce.png)

The purpose is to make more consistent the MQTT messages incoming to the agent. It is a non sense to receive aa removal message for something which must be installed (because the install message is not yet canceled)

enhances #487 