### PR TITLE
Fix for marks on geolocation map

### DIFF
--- a/tpl/computer_geolocation.html.twig
+++ b/tpl/computer_geolocation.html.twig
@@ -80,18 +80,18 @@
                   var fromDate = new Date(ui.values[0] * 1000);
                   var toDate = new Date(ui.values[1] * 1000);
                   $('#fromDateRange').html(fromDate.toDateString());
-                  $('#showdate'  + randBegin).val(fromDate.toString());
+                  $('#showdate'  + randBegin).val(fromDate.toString().slice(0, 33));
                   $('#toDateRange').html(toDate.toDateString());
-                  $('#showdate' + randEnd).val(toDate.toString());
+                  $('#showdate' + randEnd).val(toDate.toString().slice(0, 33));
                   loadMarkers();
               }
           });
           var fromDate = new Date(sliderRange.slider("values", 0) * 1000);
           var toDate = new Date(sliderRange.slider("values", 1) * 1000);
           $('#fromDateRange').html(fromDate.toDateString());
-          $('#showdate'  + randBegin).val(fromDate.toString());
+          $('#showdate'  + randBegin).val(fromDate.toString().slice(0, 33));
           $('#toDateRange').html(toDate.toDateString());
-          $('#showdate' + randEnd).val(toDate.toString());
+          $('#showdate' + randEnd).val(toDate.toString().slice(0, 33));
           loadMarkers();
       }
 


### PR DESCRIPTION
Hi, @flyve-mdm/backend-development 

In this PR I include these changes:

- Edit datetime format for beginDate parameter
- Edit datetime format for endDate parameter

### Bug description

The bug is caused by that PHP can't create a datetime from string with format:

> Fri Apr 06 2018 19:48:48 GMT-0400 (-04)

This generate a error 500 in:
`new DateTime('Fri Apr 06 2018 19:48:48 GMT-0400 (-04)');`


### The soluction

Shorten datetime string to 33 characters.

Closes #499 
