### PR TITLE
Render policy value with Twig

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,3 +94,30 @@ ul#menu ul.ssmenu {
    background: #FEC95C;
    cursor: pointer;
 }
+
+/*---------------- POLICY VALUE ----------------*/
+.plugin_flyvemdm_policy_value{
+    display: inline-block;
+    width: 100%;
+    max-width: 100%;
+    overflow-y: auto;
+}
+
+.plugin_flyvemdm_policy_value table{
+    width: 100%
+}
+.plugin_flyvemdm_policy_value table > tbody > tr > td span.no-wrap a{
+    margin-right: .5em;
+}
+.plugin_flyvemdm_policy_value table > tbody > tr > td span.no-wrap{
+    margin-right: 3em;
+}
+.plugin_flyvemdm_policy_value table .select2-container{
+    width: 90%
+}
+.plugin_flyvemdm_policy_value table > tbody > tr > td span.no-wrap span.fa {
+    padding: 0;
+}
+.plugin_flyvemdm_policy_value table .select2-container .select2-choice {
+    max-width: none;
+}

--- a/inc/policybase.class.php
+++ b/inc/policybase.class.php
@@ -240,9 +240,12 @@ abstract class PluginFlyvemdmPolicyBase implements PluginFlyvemdmPolicyInterface
     * @return string
     */
    public function showValueInput($value = '', $itemType = '', $itemId = 0) {
-      $html = '<input name="value" value="' . $value . '" >';
 
-      return $html;
+      $data['itemtype'] = $itemType;
+      $data['value'] = $value;
+      $data['typeTmpl'] = PluginFlyvemdmPolicyBase::class;
+      $twig = plugin_flyvemdm_getTemplateEngine();
+      return $twig->render('policy_value.html.twig', ['data' => $data]);
    }
 
    /**

--- a/inc/policyboolean.class.php
+++ b/inc/policyboolean.class.php
@@ -89,7 +89,13 @@ class PluginFlyvemdmPolicyBoolean extends PluginFlyvemdmPolicyBase implements Pl
     * @return int|string
     */
    public function showValueInput($value = '', $itemType = '', $itemId = 0) {
-      return Dropdown::showYesNo('value', $value, -1, ['display' => false]);
+      $data['itemtype'] = $itemType;
+      $data['typeTmpl'] = PluginFlyvemdmPolicyBoolean::class;
+      $data['dropdown'] = [
+          Dropdown::showYesNo('value', $value, -1, ['display' => false])
+      ];
+      $twig = plugin_flyvemdm_getTemplateEngine();
+      return $twig->render('policy_value.html.twig', ['data' => $data]);
    }
 
    /**

--- a/inc/policydeployapplication.class.php
+++ b/inc/policydeployapplication.class.php
@@ -235,26 +235,20 @@ class PluginFlyvemdmPolicyDeployapplication extends PluginFlyvemdmPolicyBase imp
          $removeOnDelete = $value['remove_on_delete'];
       }
 
-      $packageDropdown = PluginFlyvemdmPackage::dropdown([
-         'display'      => false,
-         'displaywith'  => ['alias'],
-         'name'         => 'items_id',
-         'value'        => $itemId,
-      ]);
-
-      $removeDropdown = Dropdown::showYesNo('value[remove_on_delete]', $removeOnDelete,
-                                          -1, ['display' => false]);
-
-      $data = [
-            'package'     => [
-               'dropdown'         => $packageDropdown,
-               'itemtype'         => $itemtype
-            ],
-            'remove'      =>      $removeDropdown
+      $data['typeTmpl'] = $itemtype;
+      $data['itemtype'] = $itemtype;
+      $data['dropdown'] = [
+            PluginFlyvemdmPackage::dropdown([
+                  'display'      => false,
+                  'displaywith'  => ['alias'],
+                  'name'         => 'items_id',
+                  'value'        => $itemId,
+               ]),
+            Dropdown::showYesNo('value[remove_on_delete]', $removeOnDelete, -1, ['display' => false])
       ];
 
       $twig = plugin_flyvemdm_getTemplateEngine();
-      return $twig->render('policy_deploy_app_form.html.twig', $data);
+      return $twig->render('policy_value.html.twig', ['data' => $data]);
    }
 
    /**

--- a/inc/policydeployfile.class.php
+++ b/inc/policydeployfile.class.php
@@ -279,37 +279,26 @@ class PluginFlyvemdmPolicyDeployfile extends PluginFlyvemdmPolicyBase implements
          $destination = substr($value['destination'], $cut);
          $destination_base = substr($value['destination'], 0, $cut);
       }
-      $filesDropdown = PluginFlyvemdmFile::dropdown([
-         'display'   => false,
-         'name'      => 'items_id',
-         'value'     => $itemId,
-      ]);
-
-      //Copy to
       $path = new PluginFlyvemdmWellknownpath();
       $path->getFromDBByPath($destination_base);
-
-      $knownPathDropdown = PluginFlyvemdmWellknownpath::dropdown([
-         'display'   => false,
-         'name'      => 'destination_base',
-         'value'     => $path->getID(),
-      ]);
-
-      $removeDropdown = Dropdown::showYesNo('value[remove_on_delete]', $removeOnDelete,
-                                                -1, ['display' => false]);
-
-      $data = [
-            'files'         => [
-                  'dropdown'        => $filesDropdown,
-                  'itemtype'        => $itemtype,
-                  'knownPath'       => $knownPathDropdown,
-                  'destination'     => $destination,
-            ],
-            'remove'       =>  $removeDropdown,
+      $data['destination'] = $destination;
+      $data['typeTmpl'] = $itemtype;
+      $data['itemtype'] = $itemtype;
+      $data['dropdown'] = [
+            PluginFlyvemdmFile::dropdown([
+                  'display'   => false,
+                  'name'      => 'items_id',
+                  'value'     => $itemId,
+               ]),
+            PluginFlyvemdmWellknownpath::dropdown([
+            'display'   => false,
+            'name'      => 'destination_base',
+            'value'     => $path->getID(),
+            ]),
+            Dropdown::showYesNo('value[remove_on_delete]', $removeOnDelete, -1, ['display' => false])
       ];
-
       $twig = plugin_flyvemdm_getTemplateEngine();
-      return $twig->render('policy_deploy_file_form.html.twig', $data);
+      return $twig->render('policy_value.html.twig', ['data' => $data]);
    }
 
    /**

--- a/inc/policydropdown.class.php
+++ b/inc/policydropdown.class.php
@@ -102,7 +102,13 @@ class PluginFlyvemdmPolicyDropdown extends PluginFlyvemdmPolicyBase implements P
     * @return int|string
     */
    public function showValueInput($value = '', $itemType = '', $itemId = 0) {
-      return Dropdown::showFromArray('value', $this->valueList, ['display' => false, 'value' => $value]);
+      $data['itemtype'] = $itemType;
+      $data['typeTmpl'] = PluginFlyvemdmPolicyDropdown::class;
+      $data['dropdown'] = [
+          Dropdown::showFromArray('value', $this->valueList, ['display' => false, 'value' => $value])
+      ];
+      $twig = plugin_flyvemdm_getTemplateEngine();
+      return $twig->render('policy_value.html.twig', ['data' => $data]);
    }
 
    /**

--- a/tests/suite-unit/PluginFlyvemdmPolicyBase.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBase.php
@@ -123,7 +123,11 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
     */
    public function testShowValueInput() {
       list($policy) = $this->createNewPolicyInstance();
-      $this->string($policy->showValueInput())->isEqualTo('<input name="value" value="" >');
+      $data['itemtype'] = '';
+      $data['value'] = '';
+      $data['typeTmpl'] = \PluginFlyvemdmPolicyBase::class;
+      $twig = plugin_flyvemdm_getTemplateEngine();
+      $this->string($policy->showValueInput())->isEqualTo($twig->render('policy_value.html.twig', ['data' => $data]));
    }
 
    /**

--- a/tpl/fleet_policy.html.twig
+++ b/tpl/fleet_policy.html.twig
@@ -81,7 +81,8 @@
           });
 
           function editPolicy(policyId, taskId) {
-              $('#policy_editor').dialog('open');
+              var editorId = "#policy_editor";
+              $(editorId).dialog('option', 'position', 'center');
               $.ajax({
                   url: '../ajax/policyValue.php',
                   method: 'POST',
@@ -94,6 +95,7 @@
                   },
                   success: function (response) {
                       $('#policy_editor_form').html(response);
+                      $(editorId).dialog('open');
                   }
               });
           }

--- a/tpl/policy_value.html.twig
+++ b/tpl/policy_value.html.twig
@@ -1,0 +1,75 @@
+    <script type="text/javascript">
+       var editorId = "#policy_editor";
+    </script>
+{% if data.typeTmpl is same as("PluginFlyvemdmFile") %}
+    <!-- Template Deploy file -->
+    <div class="plugin_flyvemdm_policy_value">
+        <table>
+            <tbody>
+                <tr>
+                    <td>
+                        {{ data.dropdown[0]|raw }}
+                    </td>
+                    <td>
+                        {{ __('copy to', 'flyvemdm') }}
+                    </td>
+                    <td>
+                        {{ data.dropdown[1]|raw }}
+                    </td>
+                    <td>
+                        <input type="text" name="value[destination]" value="{{ data.destination }}">
+                    </td>
+                    <td>
+                        {{ __('Remove when the policy is removed', 'flyvemdm') }}
+                    </td>
+                    <td>
+                        {{ data.dropdown[2]|raw }}
+                        <input type="hidden" name="itemtype" value="{{ data.itemtype }}">
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <script type="text/javascript">
+       $(document).find(editorId).dialog("option", "width", 1000);
+    </script>
+{% elseif data.typeTmpl is same as("PluginFlyvemdmPackage") %}
+    <!-- Template Package -->
+    <div class="plugin_flyvemdm_policy_value">
+        <table>
+            <tbody>
+                <tr>
+                    <td>
+                        {{ data.dropdown[0]|raw }}
+                    </td>
+                    <td style="text-align: center;">
+                        {{ __('copy to', 'flyvemdm') }}
+                    </td>
+                    <td>
+                        {{ data.dropdown[1]|raw }}
+                        <input type="hidden" name="itemtype" value="{{ data.itemtype }}">
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <script type="text/javascript">
+       $(document).find(editorId).dialog("option", "width", 500);
+    </script>
+{% elseif data.typeTmpl is same as("PluginFlyvemdmPolicyBoolean") or data.typeTmpl is same as("PluginFlyvemdmPolicyDropdown") %}
+    <!-- Template Boolean || Dropdown -->
+    <div class="plugin_flyvemdm_policy_value">
+            {{ data.dropdown[0]|raw }}
+    </div>
+    <script type="text/javascript">
+       $(document).find(editorId).dialog("option", "width", 200);
+    </script>
+{% elseif data.typeTmpl is same as("PluginFlyvemdmPolicyBase") %}
+    <!-- Template Base -->
+    <div class="plugin_flyvemdm_policy_value">
+            <input name="value" value="{{ data.value }}" >
+    </div>
+    <script type="text/javascript">
+       $(document).find(editorId).dialog("option", "width", 200);
+    </script>
+{% endif %}


### PR DESCRIPTION
Hi, @flyve-mdm/backend-development.

### Changes description

Refactor in policy add and update. Use twig template engine for policy value. Edit showValueInput methods of classes corresponding to each value type.

### Print screen
Add policy - Deploy file:
![image](https://user-images.githubusercontent.com/17582750/40807235-bb2393f2-64f1-11e8-85f7-a5c8505592d2.png)

Add policy - Deploy Application
![image](https://user-images.githubusercontent.com/17582750/40807334-07d5f212-64f2-11e8-9683-e0388bb70b7f.png)

Update policy - Deploy file
![image](https://user-images.githubusercontent.com/17582750/40807386-2b9bffb6-64f2-11e8-86b6-1db42a28e8b2.png)


### References

Related #308
