### PR TITLE
 Enhance status tests

### DIFF
--- a/tests/src/Flyvemdm/Tests/CommonTestCase.php
+++ b/tests/src/Flyvemdm/Tests/CommonTestCase.php
@@ -225,17 +225,12 @@ class CommonTestCase extends GlpiCommonTestCase {
          '$version'
       )";
 
-      try {
-         $DB->query($query);
-         $mysqlError = $DB->error();
-         $flyvemdmFile = new \PluginFlyvemdmFile();
-         $flyvemdmFile->getFromDBByCrit(['name' => $fileName]);
-         $this->boolean($flyvemdmFile->isNewItem())->isFalse($mysqlError);
-         return $flyvemdmFile;
-      } catch (\Exception $e) {
-         echo $e->getMessage();
-         $this->stop();
-      }
+      $DB->query($query);
+      $mysqlError = $DB->error();
+      $flyvemdmFile = new \PluginFlyvemdmFile();
+      $flyvemdmFile->getFromDBByCrit(['name' => $fileName]);
+      $this->boolean($flyvemdmFile->isNewItem())->isFalse($mysqlError);
+      return $flyvemdmFile;
    }
 
    /**
@@ -514,17 +509,12 @@ class CommonTestCase extends GlpiCommonTestCase {
          ''
       )";
 
-      try {
-         $DB->query($query);
-         $mysqlError = $DB->error();
-         $flyvemdmPackage = new \PluginFlyvemdmPackage();
-         $flyvemdmPackage->getFromDBByCrit(['package_name' => $dumbPackageName]);
-         $this->boolean($flyvemdmPackage->isNewItem())->isFalse($mysqlError);
-         return $flyvemdmPackage;
-      } catch (\Exception $e) {
-         echo $e->getMessage();
-         $this->stop();
-      }
+      $DB->query($query);
+      $mysqlError = $DB->error();
+      $flyvemdmPackage = new \PluginFlyvemdmPackage();
+      $flyvemdmPackage->getFromDBByCrit(['package_name' => $dumbPackageName]);
+      $this->boolean($flyvemdmPackage->isNewItem())->isFalse($mysqlError);
+      return $flyvemdmPackage;
    }
 
    /**

--- a/tests/suite-unit/PluginFlyvemdmPolicyBase.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBase.php
@@ -169,7 +169,7 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
     * @tags testTranslateData
     */
    public function testGetEnumBaseTaskStatus() {
-      $this->array(\PluginFlyvemdmPolicyBase::getEnumBaseTaskStatus())->hasKeys([
+      $expectedStatuses = [
          'pending',
          'received',
          'done',
@@ -177,6 +177,26 @@ class PluginFlyvemdmPolicyBase extends CommonTestCase {
          'canceled',
          'incompatible',
          'overriden',
-      ]);
+      ];
+
+      $statuses = \PluginFlyvemdmPolicyBase::getEnumBaseTaskStatus();
+      $this->array($statuses)->hasKeys($expectedStatuses);
+      $this->array($statuses)->size->isEqualTo(count($expectedStatuses));
+   }
+
+   /**
+    * Used in other test classes of policies
+    */
+   public function providerFilterStatus() {
+      $statuses = \PluginFlyvemdmPolicyBase::getEnumBaseTaskStatus();
+      $providedStatuses = [];
+      foreach ($statuses as $status => $localized) {
+         $providedStatuses[] = [
+            'status'   => $status,
+            'expected' => $status
+         ];
+      }
+
+      return $providedStatuses;
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyBoolean.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyBoolean.php
@@ -112,40 +112,30 @@ class PluginFlyvemdmPolicyBoolean extends CommonTestCase {
          ->contains("<option value='0'>No</option><option value='1' selected>Yes</option>");
    }
 
-   public function filterStatusProvider() {
-      return [
-         [
-            'status' => 'received',
-            'expected' => 'received'
-         ],
-         [
-            'status' => 'done',
-            'expected' => 'done'
-         ],
-         [
-            'status' => 'failed',
-            'expected' => 'failed'
-         ],
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $this->array($statuses)->size->isEqualTo(7);
+
+      $statuses = array_merge($statuses, [
          [
             'status' => 'invalid',
             'expected' => null
          ],
-      ];
+      ]);
+
+      return $statuses;
    }
 
    /**
-    * @dataProvider filterStatusProvider
-    * @param mixed $status
-    * @param mixed $expected
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
     */
    public function testFilterStatus($status, $expected) {
-      $policy = new \PluginFlyvemdmPolicy();
-      $policy->fields = [
-         'symbol' => 'dummy',
-         'unicity' => '1',
-         'group' => 'dummy',
-      ];
-      $policyBoolean = new \PluginFlyvemdmPolicyBoolean($policy);
-      $this->variable($policyBoolean->filterStatus($status))->isEqualTo($expected);
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('storageEncryption');
+      $policyObject = new \PluginFlyvemdmPolicyBoolean($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployapplication.php
@@ -215,44 +215,36 @@ class PluginFlyvemdmPolicyDeployapplication extends CommonTestCase {
       //$this->string($policy->showValue($mockInstance))->isEqualTo("$alias ($name)");
    }
 
-   public function filterStatusProvider() {
-      return [
-         [
-            'status' => 'received',
-            'expected' => 'received'
-         ],
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $statuses = array_merge($statuses, [
          [
             'status' => 'waiting',
             'expected' => 'waiting'
          ],
-         [
-            'status' => 'done',
-            'expected' => 'done'
-         ],
-         [
-            'status' => 'failed',
-            'expected' => 'failed'
-         ],
+      ]);
+      $this->array($statuses)->size->isEqualTo(8);
+
+      $statuses = array_merge($statuses, [
          [
             'status' => 'invalid',
             'expected' => null
          ],
-      ];
+      ]);
+
+      return $statuses;
    }
 
    /**
-    * @dataProvider filterStatusProvider
-    * @param unknown $status
-    * @param unknown $expected
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
     */
    public function testFilterStatus($status, $expected) {
-      $policy = new \PluginFlyvemdmPolicy();
-      $policy->fields = [
-         'symbol' => 'dummy',
-         'unicity' => '1',
-         'group' => 'dummy',
-      ];
-      $policyBoolean = new \PluginFlyvemdmPolicyDeployapplication($policy);
-      $this->variable($policyBoolean->filterStatus($status))->isEqualTo($expected);
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('deployApp');
+      $policyObject = new \PluginFlyvemdmPolicyDeployapplication($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDeployfile.php
@@ -227,7 +227,7 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
     */
    public function testUnicityCheck() {
       list($policy) = $this->createNewPolicyInstance();
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmFleet::class);
       $mockInstance->getMockController()->getID = 1;
       $fileInDb = $this->createDummyFile(0);
       $this->boolean($policy->unicityCheck(['destination' => 'filename.ext'],
@@ -240,7 +240,7 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
     */
    public function testConflictCheck() {
       list($policy) = $this->createNewPolicyInstance();
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmFleet::class);
       $mockInstance->getMockController()->getID = 1;
       $fileInDb = $this->createDummyFile(0);
       $this->boolean($policy->conflictCheck(['destination' => 'filename.ext'],
@@ -253,7 +253,7 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
     */
    public function testPre_unapply() {
       list($policy) = $this->createNewPolicyInstance();
-      $mockInstance = $this->newMockInstance('\PluginFlyvemdmFleet');
+      $mockInstance = $this->newMockInstance(\PluginFlyvemdmFleet::class);
       $mockInstance->getMockController()->getID = 1;
       $fileInDb = $this->createDummyFile(0);
 
@@ -316,44 +316,36 @@ class PluginFlyvemdmPolicyDeployfile extends CommonTestCase {
       ]))->string($output['value']['destination'])->isEqualTo('%SDCARD%targetString');
    }
 
-   public function filterStatusProvider() {
-      return [
-         [
-            'status' => 'received',
-            'expected' => 'received'
-         ],
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $statuses = array_merge($statuses, [
          [
             'status' => 'waiting',
             'expected' => 'waiting'
          ],
-         [
-            'status' => 'done',
-            'expected' => 'done'
-         ],
-         [
-            'status' => 'failed',
-            'expected' => 'failed'
-         ],
+      ]);
+      $this->array($statuses)->size->isEqualTo(8);
+
+      $statuses = array_merge($statuses, [
          [
             'status' => 'invalid',
             'expected' => null
          ],
-      ];
+      ]);
+
+      return $statuses;
    }
 
    /**
-    * @dataProvider filterStatusProvider
-    * @param unknown $status
-    * @param unknown $expected
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
     */
    public function testFilterStatus($status, $expected) {
-      $policy = new \PluginFlyvemdmPolicy();
-      $policy->fields = [
-         'symbol' => 'dummy',
-         'unicity' => '1',
-         'group' => 'dummy',
-      ];
-      $policyBoolean = new \PluginFlyvemdmPolicyDeployfile($policy);
-      $this->variable($policyBoolean->filterStatus($status))->isEqualTo($expected);
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('deployFile');
+      $policyObject = new \PluginFlyvemdmPolicyDeployfile($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyDropdown.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyDropdown.php
@@ -115,4 +115,30 @@ class PluginFlyvemdmPolicyDropdown extends CommonTestCase {
       $this->array($policy->translateData())->isEqualTo(json_decode($this->dataField['type_data'],
          true));
    }
+
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $this->array($statuses)->size->isEqualTo(7);
+
+      $statuses = $statuses + [
+         [
+            'status' => 'invalid',
+            'expected' => null
+         ],
+      ];
+      return $statuses;
+   }
+
+   /**
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
+    */
+   public function testFilterStatus($status, $expected) {
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('passwordQuality');
+      $policyObject = new \PluginFlyvemdmPolicyDropdown($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
+   }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyInteger.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyInteger.php
@@ -93,40 +93,30 @@ class PluginFlyvemdmPolicyInteger extends CommonTestCase {
       $this->boolean($policy->getMqttMessage(null, null, '1'))->isFalse();
    }
 
-   public function filterStatusProvider() {
-      return [
-         [
-            'status' => 'received',
-            'expected' => 'received'
-         ],
-         [
-            'status' => 'done',
-            'expected' => 'done'
-         ],
-         [
-            'status' => 'failed',
-            'expected' => 'failed'
-         ],
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $this->array($statuses)->size->isEqualTo(7);
+
+      $statuses = array_merge($statuses, [
          [
             'status' => 'invalid',
             'expected' => null
          ],
-      ];
+      ]);
+
+      return $statuses;
    }
 
    /**
-    * @dataProvider filterStatusProvider
-    * @param mixed $status
-    * @param mixed $expected
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
     */
-   public function testFilterStatus($status, $expected) {
-      $policy = new \PluginFlyvemdmPolicy();
-      $policy->fields = [
-         'symbol' => 'dummy',
-         'unicity' => '1',
-         'group' => 'dummy',
-      ];
-      $policyBoolean = new \PluginFlyvemdmPolicyInteger($policy);
-      $this->variable($policyBoolean->filterStatus($status))->isEqualTo($expected);
+    public function testFilterStatus($status, $expected) {
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('passwordMinLength');
+      $policyObject = new \PluginFlyvemdmPolicyInteger($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyInteger.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyInteger.php
@@ -113,7 +113,7 @@ class PluginFlyvemdmPolicyInteger extends CommonTestCase {
     * @param string $status
     * @param string $expected
     */
-    public function testFilterStatus($status, $expected) {
+   public function testFilterStatus($status, $expected) {
       $policyDefinition = new \PluginFlyvemdmPolicy();
       $policyDefinition->getFromDBBySymbol('passwordMinLength');
       $policyObject = new \PluginFlyvemdmPolicyInteger($policyDefinition);

--- a/tests/suite-unit/PluginFlyvemdmPolicyRemoveapplication.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyRemoveapplication.php
@@ -161,4 +161,36 @@ class PluginFlyvemdmPolicyRemoveapplication extends CommonTestCase {
          ->string($result[$this->dataField['symbol']])->isEqualTo($packageName);
    }
 
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses = $policyBaseTest->providerFilterStatus();
+      $statuses = array_merge($statuses, [
+         [
+            'status' => 'waiting',
+            'expected' => 'waiting'
+         ],
+      ]);
+      $this->array($statuses)->size->isEqualTo(8);
+
+      $statuses = array_merge($statuses, [
+         [
+            'status' => 'invalid',
+            'expected' => null
+         ],
+      ]);
+
+      return $statuses;
+   }
+
+   /**
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
+    */
+   public function testFilterStatus($status, $expected) {
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('deployApp');
+      $policyObject = new \PluginFlyvemdmPolicyRemoveapplication($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
+   }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyString.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyString.php
@@ -75,40 +75,30 @@ class PluginFlyvemdmPolicyString extends CommonTestCase {
       $this->array($array)->hasKey($symbol)->string($array[$symbol])->isEqualTo('a little string');
    }
 
-   public function filterStatusProvider() {
-      return [
-         [
-            'status' => 'received',
-            'expected' => 'received'
-         ],
-         [
-            'status' => 'done',
-            'expected' => 'done'
-         ],
-         [
-            'status' => 'failed',
-            'expected' => 'failed'
-         ],
+   public function providerFilterStatus() {
+      $policyBaseTest = new PluginFlyvemdmPolicyBase();
+      $statuses= $policyBaseTest->providerFilterStatus();
+      $this->array($statuses)->size->isEqualTo(7);
+
+      $statuses = array_merge($statuses, [
          [
             'status' => 'invalid',
             'expected' => null
          ],
-      ];
+      ]);
+
+      return $statuses;
    }
 
    /**
-    * @dataProvider filterStatusProvider
-    * @param mixed $status
-    * @param mixed $expected
+    * @dataProvider providerFilterStatus
+    * @param string $status
+    * @param string $expected
     */
-   public function testFilterStatus($status, $expected) {
-      $policy = new \PluginFlyvemdmPolicy();
-      $policy->fields = [
-         'symbol' => 'dummy',
-         'unicity' => '1',
-         'group' => 'dummy',
-      ];
-      $policyBoolean = new \PluginFlyvemdmPolicyString($policy);
-      $this->variable($policyBoolean->filterStatus($status))->isEqualTo($expected);
+    public function testFilterStatus($status, $expected) {
+      $policyDefinition = new \PluginFlyvemdmPolicy();
+      $policyDefinition->getFromDBBySymbol('passwordMinLength');
+      $policyObject = new \PluginFlyvemdmPolicyString($policyDefinition);
+      $this->variable($policyObject->filterStatus($status))->isEqualTo($expected);
    }
 }

--- a/tests/suite-unit/PluginFlyvemdmPolicyString.php
+++ b/tests/suite-unit/PluginFlyvemdmPolicyString.php
@@ -95,7 +95,7 @@ class PluginFlyvemdmPolicyString extends CommonTestCase {
     * @param string $status
     * @param string $expected
     */
-    public function testFilterStatus($status, $expected) {
+   public function testFilterStatus($status, $expected) {
       $policyDefinition = new \PluginFlyvemdmPolicy();
       $policyDefinition->getFromDBBySymbol('passwordMinLength');
       $policyObject = new \PluginFlyvemdmPolicyString($policyDefinition);


### PR DESCRIPTION
Better unit tests 

we must not directly set $object->fields in an object.

this property must be considered private. Someday it will.

### Changes description

Generalize tests on task statuses

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |2|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A