### PR TITLE
WIP Add locks to protect concurrent rules edition

### DIFF
--- a/inc/exception/entityruleeditionexception.class.php
+++ b/inc/exception/entityruleeditionexception.class.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace GlpiPlugin\Flyvemdm\Exception;
+
+
+class EntityRuleEditionException extends \Exception {}

--- a/inc/fusioninventory.class.php
+++ b/inc/fusioninventory.class.php
@@ -29,7 +29,8 @@
  * ------------------------------------------------------------------------------
  */
 
- use GlpiPlugin\Flyvemdm\Exception\FusionInventoryRuleInconsistency;
+use GlpiPlugin\Flyvemdm\Exception\FusionInventoryRuleInconsistency;
+use GlpiPlugin\Flyvemdm\Exception\EntityRuleEditionException;
 
 if (!defined('GLPI_ROOT')) {
    die("Sorry. You can't access this file directly");
@@ -38,6 +39,9 @@ if (!defined('GLPI_ROOT')) {
 class PluginFlyvemdmFusionInventory {
 
    const RULE_NAME = 'Flyve MDM invitation to entity';
+
+   const LOCK_NAME = 'flyvemdm_entityRule';
+
 
    /**
     * Creates or updates an entity rule
@@ -50,6 +54,10 @@ class PluginFlyvemdmFusionInventory {
          $rule = $this->getRule($entityId);
       } catch (FusionInventoryRuleInconsistency $exception) {
          Session::addMessageAfterRedirect(__('Unable to get rule for entity', 'flyvemdm'),
+            true, ERROR);
+         return;
+      } catch (EntityRuleEditionException $exception) {
+         Session::addMessageAfterRedirect(__('Cannot get lock for entity rules edition', 'flyvemdm'),
             true, ERROR);
          return;
       }
@@ -117,6 +125,19 @@ class PluginFlyvemdmFusionInventory {
       ]);
 
       $ruleId = $row[$ruleFk];
+
+      // get a lock
+      $attempts = 0;
+      $locked = 0;
+      do {
+         $locked = $DB->getLock(self::LOCK_NAME);
+         usleep(50000); // 50 milliseconds
+         $attempts++;
+      } while ($locked !== 1 && $attempts < 10);
+      if ($locked !== 1) {
+         return; // No lock, then give up disabling
+      }
+
       $rows = $ruleCriteria->find("`$ruleFk` = '$ruleId' AND `criteria` = 'tag' AND `condition` = '0'");
       if (count($rows) === 0) {
          $rule = new PluginFusioninventoryInventoryRuleEntity();
@@ -125,6 +146,7 @@ class PluginFlyvemdmFusionInventory {
             'is_active' => '0',
          ]);
       }
+      $DB->releaseLock(self::LOCK_NAME);
    }
 
    /**
@@ -144,9 +166,22 @@ class PluginFlyvemdmFusionInventory {
     *
     * @return PluginFusioninventoryInventoryRuleEntity|null
     * @throws FusionInventoryRuleInconsistency
+    * @throws EntityRuleEditionException
     */
    private function getRule($entityId, $create = true) {
       global $DB;
+
+      // get a lock
+      $attempts = 0;
+      $locked = 0;
+      do {
+         $locked = $DB->getLock(self::LOCK_NAME);
+         usleep(50000); // 50 milliseconds
+         $attempts++;
+      } while ($locked !== 1 && $attempts < 10);
+      if ($locked !== 1) {
+         throw new EntityRuleEditionException(__('Cannot get lock for entity rules edition'));
+      }
 
       $ruleEntityTable = PluginFusioninventoryInventoryRuleEntity::getTable();
       $ruleActionTable = RuleAction::getTable();
@@ -175,13 +210,16 @@ class PluginFlyvemdmFusionInventory {
          $rule = new PluginFusioninventoryInventoryRuleEntity();
          $row = $result->next();
          $rule->getFromDB($row['id']);
+         $DB->releaseLock(self::LOCK_NAME);
          return $rule;
       }
       if ($result->count() > 1) {
+         $DB->releaseLock(self::LOCK_NAME);
          throw new FusionInventoryRuleInconsistency(__('Import rule is not unique'));
       }
 
       if (!$create) {
+         $DB->releaseLock(self::LOCK_NAME);
          return null;
       }
 
@@ -203,6 +241,7 @@ class PluginFlyvemdmFusionInventory {
          'field'                    => Entity::getForeignKeyField(),
          'value'                    => $entityId,
       ]);
+      $DB->releaseLock(self::LOCK_NAME);
       return $rule;
    }
 }


### PR DESCRIPTION
Experimental - Add locks to protect concurrent rules edition

The purpose is to avoid simultaneous modification of rules in some specific cases. 

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |2|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A