### PR TITLE
Add (basic) periodic geolocation

### DIFF
--- a/install/policies/mdm.php
+++ b/install/policies/mdm.php
@@ -34,5 +34,34 @@ if (!defined('GLPI_ROOT')) {
 }
 
 $category = 'Mobile Device Management';
-return [
+$mdm = [
 ];
+
+// TODO Specific category because we will have new features related to geolocation
+// - disable geolocation reporting with time intervals
+// - disable geolocation reporting with geographic areas
+$category = 'Mobile Device Management > Geolocation';
+$mdmGeolocation = [
+   [
+      'name'                                => __('Periodic geolocation', 'flyvemdm'),
+      'symbol'                              => 'periodicGeolocation',
+      'group'                               => 'encryption',
+      'type'                                => 'int',
+      'type_data'                           => [
+         "min" => 0,
+      ],
+      'unicity'                             => 1,
+      'plugin_flyvemdm_policycategories_id' => $category,
+      'comment'                             => __('Get geolocation with a specified periodicity (in seconds) and sends it to the server.',
+         'flyvemdm'),
+      'default_value'                       => '0',
+      'recommended_value'                   => '0',
+      'is_android_system'                   => '0',
+      'android_min_version'                 => '3.0',
+      'android_max_version'                 => '0',
+      'apple_min_version'                   => '0',
+      'apple_max_version'                   => '0',
+   ],
+];
+
+return array_merge($mdm, $mdmGeolocation);

--- a/tests/src/Flyvemdm/Tests/CommonTestCase.php
+++ b/tests/src/Flyvemdm/Tests/CommonTestCase.php
@@ -645,6 +645,7 @@ class CommonTestCase extends GlpiCommonTestCase {
          'Policy/disableStreamDTMF',
          'Policy/disableStreamSystem',
          'Policy/defaultStreamType',
+         'Policy/periodicGeolocation',
       ];
    }
 }


### PR DESCRIPTION
This feature requires care about privacy. Other policies must be created to cover these concerns.

Send a periodic geolocation to the backend. Delay in seconds.

To disable the feature the agent must detect the absence of this policy when it connects again, or a null message on the topic of the policy. Both cases must disable the periodic geolocation .

Do NOT merge before aproval from @rafaelje (his technical requirements may impact the implementation of the feature server side) 

Signed-off-by: Thierry Bugier <tbugier@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A