### PR TITLE
WIP Protect policies test with a policy

### DIFF
--- a/install/policies/mdm.php
+++ b/install/policies/mdm.php
@@ -35,4 +35,22 @@ if (!defined('GLPI_ROOT')) {
 
 $category = 'Mobile Device Management';
 return [
+   [
+      'name'                                => __('Enable policies test console', 'flyvemdm'),
+      'symbol'                              => 'enablePoliciesTest',
+      'group'                               => 'mdm',
+      'type'                                => 'bool',
+      'type_data'                           => '',
+      'unicity'                             => 1,
+      'plugin_flyvemdm_policycategories_id' => $category,
+      'comment'                             => __('Give access to the policies test user interface.',
+         'flyvemdm'),
+      'default_value'                       => '0',
+      'recommended_value'                   => '0',
+      'is_android_system'                   => '0',
+      'android_min_version'                 => '3.0',
+      'android_max_version'                 => '0',
+      'apple_min_version'                   => '0',
+      'apple_max_version'                   => '0',
+   ],
 ];

--- a/tests/src/Flyvemdm/Tests/CommonTestCase.php
+++ b/tests/src/Flyvemdm/Tests/CommonTestCase.php
@@ -588,6 +588,7 @@ class CommonTestCase extends GlpiCommonTestCase {
          'Policy/disableStreamDTMF',
          'Policy/disableStreamSystem',
          'Policy/defaultStreamType',
+         'Policy/enablePoliciesTest',
       ];
    }
 }


### PR DESCRIPTION
we reverted the policy from 2.0 because we need too much time to implement it in agent 2.0.0.

This PR is for 2.1

we **require** point of view from @rafaelje  for details about implementation and impact on the backend implementation.


### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on https://github.com/flyve-mdm/android-mdm-agent/issues/545