### PR TITLE
Fix ci script for update gh-pages

### DIFF
--- a/tests/after_success.sh
+++ b/tests/after_success.sh
@@ -55,7 +55,7 @@ if [ "$GENERATE_DOCS" = true ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
         echo "creating a branch for the new documents"
         git checkout -b localCi
         git commit -m "changes to be merged"
-        git checkout -b gh-pages origin-pages/gh-pages
+        git checkout -f -b gh-pages origin-pages/gh-pages
         git rm -r development/coverage/"$TRAVIS_BRANCH"/*
         git checkout localCi development/coverage/"$TRAVIS_BRANCH"/
         git add development/coverage/"$TRAVIS_BRANCH"/*

--- a/tests/apidocs.sh
+++ b/tests/apidocs.sh
@@ -29,34 +29,30 @@ if [ "$GENERATE_DOCS" = true ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
         # clean the repo and generate the docs
         git checkout .
         wget -O apigen.phar https://github.com/ApiGen/ApiGen/releases/download/v4.1.2/apigen.phar
-        if which apigen &>/dev/null; then
-            php apigen.phar generate \
-                --access-levels=public,protected,private \
-                --todo \
-                --deprecated \
-                --tree \
-                -s inc -d development/code-documentation/"$TRAVIS_BRANCH"/
+        php apigen.phar generate \
+            --access-levels=public,protected,private \
+            --todo \
+            --deprecated \
+            --tree \
+            -s inc -d development/code-documentation/"$TRAVIS_BRANCH"/
 
-            # commit_website_files
-            echo "adding the code documentation report"
-            git add development/code-documentation/"$TRAVIS_BRANCH"/*
-            echo "creating a branch for the new documents"
-            git checkout -b localCi
-            git commit -m "changes to be merged"
-            git checkout -b gh-pages origin-pages/gh-pages
-            git rm -r development/code-documentation/"$TRAVIS_BRANCH"/*
-            git checkout localCi development/code-documentation/"$TRAVIS_BRANCH"/
-            git add development/code-documentation/"$TRAVIS_BRANCH"/*
+        # commit_website_files
+        echo "adding the code documentation report"
+        git add development/code-documentation/"$TRAVIS_BRANCH"/*
+        echo "creating a branch for the new documents"
+        git checkout -b localCi
+        git commit -m "changes to be merged"
+        git checkout -f -b gh-pages origin-pages/gh-pages
+        git rm -r development/code-documentation/"$TRAVIS_BRANCH"/*
+        git checkout localCi development/code-documentation/"$TRAVIS_BRANCH"/
+        git add development/code-documentation/"$TRAVIS_BRANCH"/*
 
-            # upload_files
-            echo "pushing the up to date documents"
-            git commit --message "docs: update code documentation report"
-            git fetch origin-pages
-            git rebase origin-pages/gh-pages
-            git push --quiet --set-upstream origin-pages gh-pages --force
-        else
-           echo "ApiGen not found, see http://www.apigen.org/"
-        fi
+        # upload_files
+        echo "pushing the up to date documents"
+        git commit --message "docs: update code documentation report"
+        git fetch origin-pages
+        git rebase origin-pages/gh-pages
+        git push --quiet --set-upstream origin-pages gh-pages --force
     fi
 else
     echo "skipping documents update"


### PR DESCRIPTION
Signed-off-by: Domingo Oropeza <doropeza@teclib.com>

### Changes description

I detected a problem showed at the image when the documentation is generated by CI
![imagen](https://user-images.githubusercontent.com/1426313/44684695-ba37f800-aa17-11e8-86fe-9fe079e0ea03.png)

The idea for this PR is to solve the problem forcing the checkout of gh-pages

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@DIOHz0r |8|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A