### PR TITLE
Restrict operator for boolean search options

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -830,6 +830,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'is_online',
          'name'               => __('Is online', 'flyvemdm'),
          'datatype'           => 'specific',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 
@@ -848,6 +849,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'has_system_permission',
          'name'               => __('Has system permission', 'flyvemdm'),
          'datatype'           => 'bool',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 
@@ -857,6 +859,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'enroll_status',
          'name'               => __('Enroll status', 'flyvemdm'),
          'datatype'           => 'bool',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 
@@ -866,6 +869,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'wipe',
          'name'               => __('Wipe requested', 'flyvemdm'),
          'datatype'           => 'bool',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 
@@ -875,6 +879,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'lock',
          'name'               => __('Lock requested', 'flyvemdm'),
          'datatype'           => 'bool',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 
@@ -2018,5 +2023,26 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
             break;
       }
       return parent::getSpecificValueToDisplay($field, $values, $options);
+   }
+
+   public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = []) {
+      if (!is_array($values)) {
+         $values = [$field => $values];
+      }
+      $options['display'] = false;
+
+      switch ($field) {
+         case 'is_online' :
+            return Dropdown::showFromArray($name, [
+               '0' => __('No', 'flyvemdm'),
+               '1' => __('Yes', 'flyvemdm'),
+            ], [
+               'value'               => $values[$field],
+               'display_emptychoice' => false,
+               'display'             => false
+            ]);
+            break;
+      }
+      return parent::getSpecificValueToSelect($field, $name, $values, $options);
    }
 }

--- a/inc/fleet.class.php
+++ b/inc/fleet.class.php
@@ -282,6 +282,7 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
          'field'              => 'is_default',
          'name'               => __('Not managed'),
          'datatype'           => 'bool',
+         'searchtype'         => ['equals'],
          'massiveaction'      => false
       ];
 

--- a/inc/policy.class.php
+++ b/inc/policy.class.php
@@ -174,6 +174,7 @@ class PluginFlyvemdmPolicy extends CommonDBTM {
          'field'         => 'is_android_system',
          'name'          => __('Requires system permission', 'flyvemdm'),
          'datatype'      => 'bool',
+         'searchtype'    => ['equals'],
          'massiveaction' => false,
       ];
 

--- a/inc/wellknownpath.class.php
+++ b/inc/wellknownpath.class.php
@@ -118,6 +118,7 @@ class PluginFlyvemdmWellknownpath extends CommonDropdown {
          'name'          => __('default'),
          'massiveaction' => false,
          'datatype'      => 'bool',
+         'searchtype'    => ['equals'],
       ];
 
       return $tab;


### PR DESCRIPTION
When we use the search engine, it must use only "is" (also "is not", but this is not necessary IMO for a bool) operator for search criterias. 

### Changes description
#### before

![image](https://user-images.githubusercontent.com/14139801/47906857-68ce3e00-de8a-11e8-8f78-afa1cc917ebd.png)
![image](https://user-images.githubusercontent.com/14139801/47906894-771c5a00-de8a-11e8-96d3-03c7046156bb.png)

#### after
![image](https://user-images.githubusercontent.com/14139801/47907252-248f6d80-de8b-11e8-845a-daa20bb159c3.png)

![image](https://user-images.githubusercontent.com/14139801/47906963-974c1900-de8a-11e8-8772-e6ff76864eea.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A