### PR TITLE
Fix date log

### DIFF
--- a/inc/mqtthandler.class.php
+++ b/inc/mqtthandler.class.php
@@ -128,6 +128,10 @@ class PluginFlyvemdmMqtthandler extends \sskaje\mqtt\MessageHandler {
 
       $mqttPath = explode('/', $topic, 4);
       if (isset($mqttPath[3])) {
+
+         // Workaround the current time for Log object
+         $_SESSION["glpi_currenttime"] = date("Y-m-d H:i:s");
+
          if ($mqttPath[3] == "Status/Ping") {
             $this->updateLastContact($topic, $message);
          } else if ($mqttPath[3] === "Status/Geolocation"  && $message != "?") {


### PR DESCRIPTION
### Changes description

I noticed in this screenshot an issue with the date of the log entries

### before
![image](https://user-images.githubusercontent.com/14139801/48632672-c94c9780-e9c1-11e8-90ac-95369f49f64c.png)

### after
![image](https://user-images.githubusercontent.com/14139801/48637838-27cc4280-e9cf-11e8-94c8-dc1767fa467f.png)

now timestamp is consistent with the actual time of the event
### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

