### PR TITLE
Give a pasword to the agent user account

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1810,6 +1810,14 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          }
       }
 
+      $user = new User();
+      $user->update([
+          User::getForeignKeyField() => $user->getID(),
+         'password'                  => $mqttClearPassword,
+         'password2'                 => $mqttClearPassword,
+         'authtype'                  => Auth::DB_GLPI,
+      ]);
+
       // The request comes from the owner of the device or the device itself, mandated by the user
       $this->fields['topic'] = $this->getTopic();
       $this->fields['mqttpasswd'] = $mqttClearPassword;


### PR DESCRIPTION
### Changes description

When the plugin creates a user for the mdm agent the user does not has a password. This is needed to consume the rest API.

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry  |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A