### PR TITLE
Revert "feat(agent): give a pasword to the agent user account"

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -558,7 +558,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
       // Useful for post_purgeItem
       $this->getTopic();
       $this->setupMqttAccess();
-      $this->fields['api_token'] = User::getToken($this->fields['users_id'], 'api_token');
+      $this->fields['api_token'] = User::getToken($this->fields[User::getForeignKeyField()], 'api_token');
    }
 
    /**

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1822,14 +1822,6 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
          }
       }
 
-      $user = new User();
-      $user->update([
-          User::getForeignKeyField() => $user->getID(),
-         'password'                  => $mqttClearPassword,
-         'password2'                 => $mqttClearPassword,
-         'authtype'                  => Auth::DB_GLPI,
-      ]);
-
       // The request comes from the owner of the device or the device itself, mandated by the user
       $this->fields['topic'] = $this->getTopic();
       $this->fields['mqttpasswd'] = $mqttClearPassword;

--- a/tests/suite-integration/PluginFlyvemdmAgent.php
+++ b/tests/suite-integration/PluginFlyvemdmAgent.php
@@ -264,6 +264,9 @@ class PluginFlyvemdmAgent extends CommonTestCase {
       // Test the agent user does not have a password
       $this->boolean(empty($agentUser->getField('password')))->isTrue();
 
+      // Test the agent user has an API token
+      $this->boolean(empty($agentUser->getField('api_token')))->isFalse();
+
       // Test the agent's user has the expected DEFAULT profile
       $config = \Config::getConfigurationValues('flyvemdm', ['agent_profiles_id']);
       $this->integer((int) $agentUser->getField('profiles_id'))->isEqualTo($config['agent_profiles_id']);


### PR DESCRIPTION
This reverts commit d398594e8950e8818b8e81edac4cfb793cebc45d.

i did a mistake: we already generate a api token at the end of enrollment for  the agent machine user. No need to store the password; let's use this token

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A