### PR TITLE
Permission to read task statuses for agents

### DIFF
--- a/install/install.class.php
+++ b/install/install.class.php
@@ -296,7 +296,7 @@ class PluginFlyvemdmInstall {
          PluginFlyvemdmPackage::$rightname      => READ,
          PluginFlyvemdmEntityConfig::$rightname => READ,
          PluginFlyvemdmGeolocation::$rightname  => CREATE,
-         PluginFlyvemdmTaskstatus::$rightname   => UPDATE,
+         PluginFlyvemdmTaskstatus::$rightname   => READ | UPDATE,
       ]);
    }
 

--- a/tests/suite-integration/ProfileRight.php
+++ b/tests/suite-integration/ProfileRight.php
@@ -52,7 +52,7 @@ class ProfileRight extends CommonTestCase {
          \PluginFlyvemdmFile::$rightname         => READ,
          \PluginFlyvemdmEntityConfig::$rightname => READ,
          \PluginFlyvemdmGeolocation::$rightname  => CREATE,
-         \PluginFlyvemdmTaskstatus::$rightname   => UPDATE,
+         \PluginFlyvemdmTaskstatus::$rightname   => READ | UPDATE,
       ];
 
       $profileRight = $this->newTestedInstance();


### PR DESCRIPTION
### Changes description

To allow the agent to get their task statuses id it needs to search it but the agent does not have the right to do it.

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@DIOHz0r |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Related #797