### PR TITLE
MQTT subcribers tab only if the agent uses it

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -157,7 +157,9 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
       if (!$this->isNewItem()) {
          $this->addStandardTab(PluginFlyvemdmTask::class, $tab, $options);
          $this->addStandardTab(PluginFlyvemdmTaskstatus::class, $tab, $options);
-         $this->addStandardTab(PluginFlyvemdmMqttlog::class, $tab, $options);
+         if ($this->fields['notification_type'] == 'mqtt') {
+            $this->addStandardTab(PluginFlyvemdmMqttlog::class, $tab, $options);
+         }
       }
       $this->addStandardTab(Notepad::class, $tab, $options);
       $this->addStandardTab(Log::class, $tab, $options);


### PR DESCRIPTION
### Changes description

A small fix to show the MQTT logs only if the agent uses that notification type

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@DIOHz0r |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #841