### PR TITLE
Don't block on minor inconsistency in DB

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -344,12 +344,17 @@ class PluginFlyvemdmTask extends CommonDBRelation {
       }
       $notifiableType = $this->fields['itemtype_applied'];
       $this->notifiable = new $notifiableType();
-      if (!$this->notifiable->getFromDB($this->fields['items_id_applied'])) {
-         Session::addMessageAfterRedirect(sprintf(__('%1$s not found', 'flyvemdm'), $this->notifiable->getTypeName()), false, ERROR);
-         return false;
+      if ($this->notifiable->getFromDB($this->fields['items_id_applied'])) {
+         return $this->policy->pre_unapply(
+            $this->fields['value'],
+            $this->fields['itemtype'],
+            $this->fields['items_id'],
+            $this->notifiable
+         );
       }
-      return $this->policy->pre_unapply($this->fields['value'], $this->fields['itemtype'],
-         $this->fields['items_id'], $this->notifiable);
+
+      Session::addMessageAfterRedirect(sprintf(__('%1$s not found', 'flyvemdm'), $this->notifiable->getTypeName()), false, ERROR);
+      return true;
    }
 
    /**


### PR DESCRIPTION
To avoid errors when cascaded deletion fails. In some cases, a broken cascaded deletion might succeed anyway. The inconsistency detected would be solved.

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@btry |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #865 
Related #N/A
Depends on #N/A