### PR TITLE
use UTC timestamp for geolocation date

### DIFF
--- a/ajax/geolocation.php
+++ b/ajax/geolocation.php
@@ -65,10 +65,15 @@ $rows = $geolocation->find($condition, '`date`', $limit);
 
 $markers = [];
 foreach ($rows as $row) {
-   $markers[] = [
-         'date'      => $row['date'],
-         'latitude'  => $row['latitude'],
-         'longitude'  => $row['longitude'],
-   ];
+
+      //switch UTC timaazone (saved in DB) to user timezone for display
+      $date = new DateTime($row['date'],new DateTimeZone('UTC'));
+      $date->setTimezone(new DateTimeZone(PluginFlyvemdmCommon::guessTimezone()));
+
+      $markers[] = [
+            'date'      => $date->format("Y-m-d H:i:s"),
+            'latitude'  => $row['latitude'],
+            'longitude'  => $row['longitude'],
+      ];
 }
 echo json_encode($markers);

--- a/install/install.class.php
+++ b/install/install.class.php
@@ -68,7 +68,7 @@ class PluginFlyvemdmInstall {
     */
    private $upgradeSteps = [
       '0.0'    => '2.0',
-      //'2.0'    => '2.1',
+      '2.0'    => '2.1',
       //'2.1'    => '3.0',
    ];
 

--- a/install/mysql/plugin_flyvemdm_empty.sql
+++ b/install/mysql/plugin_flyvemdm_empty.sql
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_flyvemdm_geolocations` (
   `computers_id` int(11) NOT NULL DEFAULT '0',
   `latitude` varchar(255) NOT NULL DEFAULT '',
   `longitude` varchar(255) NOT NULL DEFAULT '',
-  `date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `date` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `computers_id` (`computers_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/install/upgrade_to_2_1.php
+++ b/install/upgrade_to_2_1.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * LICENSE
+ *
+ * Copyright © 2016-2018 Teclib'
+ * Copyright © 2010-2018 by the FusionInventory Development Team.
+ *
+ * This file is part of Flyve MDM Plugin for GLPI.
+ *
+ * Flyve MDM Plugin for GLPI is a subproject of Flyve MDM. Flyve MDM is a mobile
+ * device management software.
+ *
+ * Flyve MDM Plugin for GLPI is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Flyve MDM Plugin for GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Flyve MDM Plugin for GLPI. If not, see http://www.gnu.org/licenses/.
+ * ------------------------------------------------------------------------------
+ * @copyright Copyright © 2018 Teclib
+ * @license   https://www.gnu.org/licenses/agpl.txt AGPLv3+
+ * @link      https://github.com/flyve-mdm/glpi-plugin
+ * @link      https://flyve-mdm.com/
+ * ------------------------------------------------------------------------------
+ */
+
+use GlpiPlugin\Flyvemdm\Mqtt\MqttConnection;
+
+if (!defined('GLPI_ROOT')) {
+   die("Sorry. You can't access this file directly");
+}
+
+class PluginFlyvemdmUpgradeTo2_1 {
+
+   /**
+    * @param Migration $migration
+    */
+   public function upgrade(Migration $migration) {
+
+      //change datetime by timestamp for glpi_plugin_flyvemdm_geolocations table
+      $table = 'glpi_plugin_flyvemdm_geolocations';
+      PluginFlyvemdmCommon::convertTableColumnToTimestamp($table, $migration);
+
+
+   }
+
+
+}

--- a/tests/suite-unit/PluginFlyvemdmGeolocation.php
+++ b/tests/suite-unit/PluginFlyvemdmGeolocation.php
@@ -99,4 +99,39 @@ class PluginFlyvemdmGeolocation extends CommonTestCase {
          $this->variable($result)->isEqualTo($expected['result']);
       }
    }
+
+   /**
+    * Test geolocate data
+    */
+   public function testGeolocationDateTime() {
+
+      $instance = $this->newMockInstance(\PluginFlyvemdmGeolocation::class);
+
+      //Data come from agent (and therefore the user)
+      $config = \Config::getConfigurationValues('flyvemdm', ['agent_profiles_id']);
+      $_SESSION['glpiactiveprofile']['id'] = $config['agent_profiles_id'];
+      $_SESSION['glpiactive_entity'] = '1';
+
+      //computer is assign to user with ID 8
+      //and FlyveMDM check current user and users_id from computer
+      $_SESSION["glpiID"] = 8;
+
+      $input = [
+         "latitude" => '49.1620987', //Caen
+         "longitude" => '-0.3457779',
+         "_datetime" => '1571118073', //2019-10-15 05:41:13 UTC
+         "_agents_id" => '1',
+         "computers_id" => '1',
+      ];
+
+      //add geolocate data to DB
+      $geolocate_id = $instance->add($input);
+      $this->integer((int)$geolocate_id)->isGreaterThan(0);
+
+      //reload object from DB
+      $instance->getFromDB($geolocate_id);
+      $this->string((string)$instance->fields['date'])->isEqualTo('2019-10-15 05:41:13');
+      $this->string((string)$instance->fields['longitude'])->isEqualTo('-0.3457779');
+      $this->string((string)$instance->fields['latitude'])->isEqualTo('49.1620987');
+   }
 }

--- a/tpl/computer_geolocation.html.twig
+++ b/tpl/computer_geolocation.html.twig
@@ -2,9 +2,9 @@
    <div id="plugin_flyvemdm_geolocationList">
       {% if beginDate is not empty and endDate is not empty %}
          <div><label for="fromDateRange">From date:</label> <span id="fromDateRange"></span>
-         <input type="hidden" id="showdate{{ randBegin }}" value="{{ beginDate|raw }}"/></div>
+         <input type="hidden" id="showdate{{ randBegin }}" value="{{ beginDate|date('Y-m-d H:i:s',timezone)}}"/></div>
          <div><label for="toDateRange">To date:</label> <span id="toDateRange"></span>
-         <input type="hidden" id="showdate{{ randEnd }}" value="{{ endDate|raw }}"/></div>
+         <input type="hidden" id="showdate{{ randEnd }}" value="{{ endDate|date('Y-m-d H:i:s',timezone)}}"/></div>
          <div id="slider-range"></div>
       {% endif %}
    </div>
@@ -68,8 +68,8 @@
 
       function initSlider(){
           var sliderRange = $("#slider-range");
-          var minDate = new Date('{{ beginDate }}').getTime() / 1000;
-          var maxDate = new Date('{{ endDate }}').getTime() / 1000;
+          var minDate = new Date("{{ beginDate|date('Y-m-d H:i:s',timezone) }}").getTime() / 1000;
+          var maxDate = new Date("{{ endDate|date('Y-m-d H:i:s',timezone) }}").getTime() / 1000;
           sliderRange.slider({
               range: true,
               min: minDate,


### PR DESCRIPTION
### Changes description

Change mysql datetime to timestamp for geolocation date with migration script
to prevent bad date managment
Now twig use server timezone to convert display date  

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A