### PR TITLE
fixx empty message whan task is delete

### DIFF
--- a/inc/mqtt/mqttsendmessagehandler.class.php
+++ b/inc/mqtt/mqttsendmessagehandler.class.php
@@ -52,6 +52,16 @@ class MqttSendMessageHandler {
       $qos = ($option = $mqttEnvelope->getContext('qos')) ? $option : 0;
       $retain = ($option = $mqttEnvelope->getContext('retain')) ? $option : 0;
       $topic = $mqttEnvelope->getContext('topic');
-      $this->connection->publish($topic, $message->getMessage(), $qos, $retain);
+      $bodyMessage = $message->getMessage();
+      if (null === $bodyMessage && strpos($topic, "defaultStreamType") === false) {
+         $chunks = explode('/', $topic);
+         switch ($chunks[3]) {
+            case 'Policy':
+               // null messages aren't sent when reseting policies values, let's fix that
+               $bodyMessage = '{"' . $chunks[4] . '":"default","taskId":"' . $chunks[6] . '"}';
+               break;
+         }
+      }
+      $this->connection->publish($topic, $bodyMessage, $qos, $retain);
    }
 }


### PR DESCRIPTION
### Changes description

when task is deleted from glpi, 
with FCM a message is send
like this
```
{"removeApp":"default","taskid":"12"}
```
but with mqtt nothing 
this PR fix this.

The message is used by agent to delete policy by task_id

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A