### PR TITLE
topic unsubscribe already done by agent update or fleet delete

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1229,27 +1229,6 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
       }
    }
 
-   /**
-    * unsubscribe from a fleet
-    */
-   public function unsubscribe() {
-      $this->update([
-            'id' => $this->getID(),
-            'plugin_flyvemdm_fleets_id' => null
-      ]);
-      $message = json_encode([], JSON_UNESCAPED_SLASHES);
-      $brokerMessage = new BrokerMessage($message);
-      $envelopeConfig = [];
-      $topic = $this->getTopic();
-      if ($topic !== null) {
-         $finalTopic = $topic . "/Subscription";
-         $envelopeConfig[] = new MqttEnvelope([
-            'topic' => $finalTopic,
-         ]);
-      }
-      $envelope = new BrokerEnvelope($brokerMessage, $envelopeConfig);
-      $this->notify($envelope);
-   }
 
    /**
     * Checks if the data provided for enrollment satisfy our requirements

--- a/inc/fleet.class.php
+++ b/inc/fleet.class.php
@@ -372,23 +372,6 @@ class PluginFlyvemdmFleet extends CommonDBTM implements PluginFlyvemdmNotifiable
     */
    public function cleanDBonPurge() {
       global $DB;
-
-      // Unsuscribe all agents from the fleet
-      $fleetId = $this->getID();
-      $query = [
-         'SELECT' => 'id',
-         'FROM'   => PluginFlyvemdmAgent::getTable(),
-         'WHERE'  => [
-            'plugin_flyvemdm_fleets_id' => $fleetId,
-         ],
-      ];
-      foreach ($DB->request($query) as $row) {
-         $agent = new PluginFlyvemdmAgent();
-         if ($agent->getFromDB($row['id'])) {
-            $agent->unsubscribe();
-         }
-      }
-
       // Force deletion regardless a file or application removal policy should take place
       $taskTable = PluginFlyvemdmTask::getTable();
       $itemtype = $this->getType();


### PR DESCRIPTION
### Changes description

When a fleet is deleted or an agent is updated and change fleets_id to default, a mqtt message with is send to device with  null topic.

The null topic is already manage by device, is not necessary to call unsubscribe method.

Moreover, this method no longer makes sense because it looks for the old fleet, after deleting it

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A