### PR TITLE
Update taskstatus rather than create new one

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -426,11 +426,21 @@ class PluginFlyvemdmTask extends CommonDBRelation {
       $agents = $item->getAgents($notifiableId);
       foreach ($agents as $agent) {
          $taskStatus = new PluginFlyvemdmTaskstatus();
-         $taskStatus->add([
-            PluginFlyvemdmAgent::getForeignKeyField() => $agent->getID(),
-            $this::getForeignKeyField()               => $this->getID(),
-            'status'                                  => 'pending',
-         ]);
+
+         //if task status exist, let's update it
+         if($taskStatus->getFromDBByCrit([PluginFlyvemdmAgent::getForeignKeyField() => $agent->getID(),
+                                          $this::getForeignKeyField()               => $this->getID()])){
+
+            $taskStatus->update(["id"     => $taskStatus->getField("id"),
+                                 "status" => 'pending']);
+         }else{
+            $taskStatus->add([
+               PluginFlyvemdmAgent::getForeignKeyField() => $agent->getID(),
+               $this::getForeignKeyField()               => $this->getID(),
+               'status'                                  => 'pending',
+            ]);
+         }
+
       }
    }
 


### PR DESCRIPTION
### Changes description

When update a package, if it attached to a task, plugin create new task status
plugin should update status if already exist

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A